### PR TITLE
feat: Add pump circuit speed helpers and fix missing OBJTYP handling

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "pyintellicenter"
-version = "0.1.8"
+version = "0.1.9"
 description = "Python library for Pentair IntelliCenter pool control systems"
 readme = "README.md"
 license = "MIT"

--- a/src/pyintellicenter/__init__.py
+++ b/src/pyintellicenter/__init__.py
@@ -181,7 +181,7 @@ try:
 except ImportError:
     _DISCOVERY_AVAILABLE = False
 
-__version__ = "0.1.8"
+__version__ = "0.1.9"
 
 __all__ = [
     # Version

--- a/src/pyintellicenter/model.py
+++ b/src/pyintellicenter/model.py
@@ -271,10 +271,22 @@ class PoolModel:
 
         Returns:
             The created/updated PoolObject, or None if type not in attribute map
+            or if required attributes are missing
         """
         pool_obj = self._objects.get(objnam)
 
         if pool_obj is None:
+            # Validate required OBJTYP attribute before creating object
+            # Some firmware versions (3.008+) return objects like _FDR where
+            # all params are stripped during pruning (key==value pattern)
+            if OBJTYP_ATTR not in params:
+                _LOGGER.debug(
+                    "Skipping object %s: missing required OBJTYP attribute (params: %s)",
+                    objnam,
+                    params,
+                )
+                return None
+
             pool_obj = PoolObject(objnam, params)
             if pool_obj.objtype in self._attribute_map:
                 self._objects[objnam] = pool_obj


### PR DESCRIPTION
## Summary
- Add `get_pump_circuit_speed()` that returns speed clamped to valid range for current mode (RPM/GPM), fixing stale value display during mode switch
- Add `get_pump_circuit_mode()` and `get_pump_circuit_limits()` helpers
- Add `get_pump_circuits()` to retrieve all PMPCIRC objects
- Skip objects missing OBJTYP attribute instead of crashing (firmware 3.008+)

## Test plan
- [x] Added 9 new tests for pump circuit helpers
- [x] Added 2 tests for missing OBJTYP handling
- [x] All 124 tests pass
- [x] mypy type checking passes
- [x] ruff linting passes

Fixes #12
Related: joyfulhouse/intellicenter#19

🤖 Generated with [Claude Code](https://claude.com/claude-code)