### PR TITLE
fix: Restore ACT attribute for set_light_effect() - fixes 404 error (v0.1.15)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,16 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.1.15] - 2026-02-26
+
+### Fixed
+
+- **set_light_effect() 404 error regression** (re-fixes issue first fixed in v0.1.7):
+  - `set_light_effect()` was sending `USE` attribute in `SETPARAMLIST`, which IntelliCenter rejects with a 404 error
+  - Correctly uses `ACT` (action trigger) attribute to set light effects; `USE` is read-only state reflection
+  - Regression was introduced in v0.1.8 (pump speed helpers commit) which accidentally removed the `ACT_ATTR` import
+  - Added regression tests to prevent recurrence (fixes #30)
+
 ## [0.1.14] - 2026-01-23
 
 ### Fixed

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "pyintellicenter"
-version = "0.1.14"
+version = "0.1.15"
 description = "Python library for Pentair IntelliCenter pool control systems"
 readme = "README.md"
 license = "MIT"
@@ -120,7 +120,13 @@ exclude_lines = [
     "raise NotImplementedError",
 ]
 
+[tool.uv.sources]
+pyintellicenter = { workspace = true }
+
 [dependency-groups]
 dev = [
+    "pyintellicenter",
+    "pytest>=9.0.1",
+    "pytest-asyncio>=1.3.0",
     "python-dotenv>=1.2.1",
 ]

--- a/src/pyintellicenter/__init__.py
+++ b/src/pyintellicenter/__init__.py
@@ -181,7 +181,7 @@ try:
 except ImportError:
     _DISCOVERY_AVAILABLE = False
 
-__version__ = "0.1.14"
+__version__ = "0.1.15"
 
 __all__ = [
     # Version

--- a/src/pyintellicenter/controller.py
+++ b/src/pyintellicenter/controller.py
@@ -19,6 +19,7 @@ from dataclasses import asdict, dataclass, field
 from typing import TYPE_CHECKING, Any, ClassVar, Protocol, runtime_checkable
 
 from .attributes import (
+    ACT_ATTR,
     ALK_ATTR,
     ASSIGN_ATTR,
     BODY_ATTR,
@@ -1320,6 +1321,10 @@ class ICModelController(ICBaseController):
     async def set_light_effect(self, objnam: str, effect: str) -> dict[str, Any]:
         """Set the color effect for a color-capable light.
 
+        Note: IntelliCenter uses ACT (action) attribute to set effects,
+        while USE attribute reflects the current state. The effect change
+        propagates to USE after IntelliCenter processes the command.
+
         Args:
             objnam: Object name of the light
             effect: Effect code (e.g., "PARTY", "CARIB", "ROYAL")
@@ -1337,7 +1342,7 @@ class ICModelController(ICBaseController):
         if effect not in LIGHT_EFFECTS:
             valid = ", ".join(LIGHT_EFFECTS.keys())
             raise ValueError(f"Invalid effect '{effect}'. Valid effects: {valid}")
-        return await self._queue_property_change(objnam, {USE_ATTR: effect})
+        return await self._queue_property_change(objnam, {ACT_ATTR: effect})
 
     def get_light_effect(self, objnam: str) -> str | None:
         """Get the current color effect for a light.

--- a/tests/test_controller.py
+++ b/tests/test_controller.py
@@ -1243,6 +1243,47 @@ class TestICModelController:
         assert len(entities["circuit_groups"]) == 1
         assert len(entities["color_light_groups"]) == 1
 
+    @pytest.mark.asyncio
+    async def test_set_light_effect_uses_act_attr(self, controller):
+        """Regression test: set_light_effect must use ACT attribute, not USE.
+
+        IntelliCenter returns 404 when USE is sent via SETPARAMLIST. The ACT
+        attribute is the action trigger; USE reflects current state read-only.
+        Regression introduced in v0.1.8 (pump speed commit) and fixed in v0.1.15.
+        """
+        controller._connection = MagicMock()
+        controller._connection.connected = True
+        controller._connection.send_request = AsyncMock(
+            return_value={"response": "200", "objectList": []}
+        )
+
+        await controller.set_light_effect("C001", "PARTY")
+
+        call_args = controller._connection.send_request.call_args
+        assert call_args[0][0] == "SETPARAMLIST"
+        params = call_args[1]["objectList"][0]["params"]
+        assert "ACT" in params, "set_light_effect must send ACT attribute (not USE)"
+        assert params["ACT"] == "PARTY"
+        assert "USE" not in params, "set_light_effect must NOT send USE attribute"
+
+    @pytest.mark.asyncio
+    async def test_set_light_effect_invalid_raises(self, controller):
+        """Test set_light_effect raises ValueError for unknown effect codes."""
+        with pytest.raises(ValueError, match="Invalid effect"):
+            await controller.set_light_effect("C001", "NOTANEFFECT")
+
+    def test_get_light_effect_reads_use_attr(self, controller, model):
+        """Test get_light_effect reads USE attribute (state reflection)."""
+        model.add_object(
+            "C001",
+            {"OBJTYP": "CIRCUIT", "SUBTYP": "INTELLI", "SNAME": "Light", "USE": "CARIB"},
+        )
+        assert controller.get_light_effect("C001") == "CARIB"
+
+    def test_get_light_effect_none_for_missing(self, controller, model):
+        """Test get_light_effect returns None when object doesn't exist."""
+        assert controller.get_light_effect("NONEXISTENT") is None
+
 
 class TestRequestCoalescing:
     """Test request coalescing behavior in ICModelController."""

--- a/uv.lock
+++ b/uv.lock
@@ -201,7 +201,7 @@ wheels = [
 
 [[package]]
 name = "pyintellicenter"
-version = "0.1.13"
+version = "0.1.15"
 source = { editable = "." }
 dependencies = [
     { name = "orjson" },
@@ -220,6 +220,9 @@ dev = [
 
 [package.dev-dependencies]
 dev = [
+    { name = "pyintellicenter" },
+    { name = "pytest" },
+    { name = "pytest-asyncio" },
     { name = "python-dotenv" },
 ]
 
@@ -237,7 +240,12 @@ requires-dist = [
 provides-extras = ["dev"]
 
 [package.metadata.requires-dev]
-dev = [{ name = "python-dotenv", specifier = ">=1.2.1" }]
+dev = [
+    { name = "pyintellicenter", editable = "." },
+    { name = "pytest", specifier = ">=9.0.1" },
+    { name = "pytest-asyncio", specifier = ">=1.3.0" },
+    { name = "python-dotenv", specifier = ">=1.2.1" },
+]
 
 [[package]]
 name = "pytest"


### PR DESCRIPTION
## Summary

- **Root cause**: `set_light_effect()` was sending `USE` attribute in `SETPARAMLIST`, which IntelliCenter rejects with a 404 error
- **Regression introduced in v0.1.8** (pump speed helpers commit #13) — accidentally removed `ACT_ATTR` import while adding pump helpers, reverting back to `USE_ATTR`
- **Fix**: Restore `ACT_ATTR` import and use `{ACT_ATTR: effect}` in the SETPARAMLIST payload (re-applies the v0.1.7 fix)

### Why ACT, not USE?
In the IntelliCenter protocol:
- `USE` reflects the **current state** (read-only from HA's perspective)
- `ACT` is the **action trigger** that tells IntelliCenter to change the effect
- Sending `USE` directly via `SETPARAMLIST` returns a 404 error

## Regression Test Added
4 new tests in `tests/test_controller.py` prevent this from regressing again:
- Asserts `ACT` attribute is in the SETPARAMLIST payload
- Asserts `USE` attribute is **not** in the payload  
- Tests `ValueError` for invalid effect codes
- Tests `get_light_effect()` reads `USE` correctly (state reflection)

## Test Plan
- [x] `uv run pytest tests/ -q` → 278 passed
- [x] `uv run ruff check --fix && uv run ruff format` → clean

Fixes joyfulhouse/intellicenter#30

🤖 Generated with [Claude Code](https://claude.com/claude-code)