### PR TITLE
refactor: extract heater mixin from ICModelController (step 4)

### DIFF
--- a/src/pyintellicenter/_mixins/__init__.py
+++ b/src/pyintellicenter/_mixins/__init__.py
@@ -12,6 +12,7 @@ from .body import _BodyMixin
 from .chemistry import _ChemistryMixin
 from .circuit_group import _CircuitGroupMixin
 from .cover import _CoverMixin
+from .heater import _HeaterMixin
 from .light import _LightMixin
 from .pump import _PumpMixin
 from .schedule import _ScheduleMixin
@@ -23,6 +24,7 @@ __all__ = [
     "_ChemistryMixin",
     "_CircuitGroupMixin",
     "_CoverMixin",
+    "_HeaterMixin",
     "_LightMixin",
     "_PumpMixin",
     "_ScheduleMixin",

--- a/src/pyintellicenter/_mixins/heater.py
+++ b/src/pyintellicenter/_mixins/heater.py
@@ -1,0 +1,143 @@
+"""Heater and setpoint helpers for :class:`ICModelController`.
+
+Provides the setters that drive a body of water's heat mode and heating/cooling
+setpoints (used by Home Assistant climate/water-heater entities), plus a
+predicate that reports whether any heater attached to a body supports cooling.
+The setters route through the controller's request-coalescing engine so rapid
+successive calls are batched into a single command.
+"""
+
+from __future__ import annotations
+
+import logging
+from typing import Any
+
+from ..attributes import (
+    BODY_ATTR,
+    HEATER_TYPE,
+    HITMP_ATTR,
+    LOTMP_ATTR,
+    MODE_ATTR,
+    HeaterType,
+)
+from ._base import _MixinBase
+
+_LOGGER = logging.getLogger(__name__)
+
+
+class _HeaterMixin(_MixinBase):
+    """Heater/setpoint convenience methods for ``ICModelController``."""
+
+    async def set_heat_mode(self, body_objnam: str, mode: HeaterType) -> dict[str, Any]:
+        """Set the heat mode for a body of water.
+
+        Args:
+            body_objnam: Object name of the body (pool or spa)
+            mode: HeaterType enum value
+
+        Returns:
+            Response dictionary
+
+        Example:
+            await controller.set_heat_mode("B1101", HeaterType.HEATER)
+        """
+        return await self._queue_property_change(body_objnam, {MODE_ATTR: str(mode.value)})
+
+    async def set_setpoint(self, body_objnam: str, temperature: int) -> dict[str, Any]:
+        """Set the heating setpoint for a body of water.
+
+        This is the temperature the system will heat UP to.
+        Alias for set_heating_setpoint().
+
+        Args:
+            body_objnam: Object name of the body (pool or spa)
+            temperature: Target heating temperature (units match system config)
+
+        Returns:
+            Response dictionary
+        """
+        return await self._queue_property_change(body_objnam, {LOTMP_ATTR: str(temperature)})
+
+    async def set_heating_setpoint(self, body_objnam: str, temperature: int) -> dict[str, Any]:
+        """Set the heating setpoint for a body of water.
+
+        This is the temperature the system will heat UP to (LOTMP attribute).
+        For the cooling setpoint, use set_cooling_setpoint().
+
+        Args:
+            body_objnam: Object name of the body (pool or spa)
+            temperature: Target heating temperature (units match system config)
+
+        Returns:
+            Response dictionary
+
+        Example:
+            await controller.set_heating_setpoint("B1101", 84)
+        """
+        return await self._queue_property_change(body_objnam, {LOTMP_ATTR: str(temperature)})
+
+    async def set_cooling_setpoint(self, body_objnam: str, temperature: int) -> dict[str, Any]:
+        """Set the cooling setpoint for a body of water.
+
+        This is the temperature the system will cool DOWN to (HITMP attribute).
+        Only relevant for systems with heat pumps or chillers that support cooling.
+        The cooling setpoint must be higher than the heat setpoint.
+
+        Args:
+            body_objnam: Object name of the body (pool or spa)
+            temperature: Target cooling temperature (units match system config)
+
+        Returns:
+            Response dictionary
+
+        Example:
+            await controller.set_cooling_setpoint("B1101", 86)
+        """
+        return await self._queue_property_change(body_objnam, {HITMP_ATTR: str(temperature)})
+
+    def body_supports_cooling(self, body_objnam: str) -> bool:
+        """Check if a body has a heater that supports cooling.
+
+        UltraTemp heat pumps (SUBTYP="ULTRA") support both heating and cooling.
+        Gas heaters (SUBTYP="HEATER"), solar heaters (SUBTYP="SOLAR"), and
+        generic heaters (SUBTYP="GENERIC") do not support cooling.
+
+        This checks ALL heaters that support this body, not just the currently
+        active one, so it returns True even if the system is currently off or
+        using a different heater.
+
+        Args:
+            body_objnam: Object name of the body (pool or spa)
+
+        Returns:
+            True if any available heater for this body supports cooling
+
+        Example:
+            if controller.body_supports_cooling("B1101"):
+                # Show both heating and cooling setpoints
+                heat_sp = controller.get_body_heating_setpoint("B1101")
+                cool_sp = controller.get_body_cooling_setpoint("B1101")
+        """
+        body = self._model[body_objnam]
+        if not body:
+            _LOGGER.warning("body_supports_cooling: body %s not found", body_objnam)
+            return False
+
+        # Check ALL heaters to see if any support this body AND can cool
+        all_heaters = list(self._model.get_by_type(HEATER_TYPE))
+
+        for heater in all_heaters:
+            # Check if this heater supports this body
+            supported_bodies = heater[BODY_ATTR]
+            if supported_bodies:
+                body_list = supported_bodies.split(" ")
+                if body_objnam in body_list:
+                    # Check if this heater supports cooling via either:
+                    # 1. Subtype being ULTRA (UltraTemp heat pump)
+                    # 2. Having a COOL attribute set to "ON"
+                    has_ultra = heater.subtype == "ULTRA"
+                    has_cool = heater["COOL"] == "ON"
+                    if has_ultra or has_cool:
+                        return True
+
+        return False

--- a/src/pyintellicenter/controller.py
+++ b/src/pyintellicenter/controller.py
@@ -23,6 +23,7 @@ from ._mixins import (
     _ChemistryMixin,
     _CircuitGroupMixin,
     _CoverMixin,
+    _HeaterMixin,
     _LightMixin,
     _PumpMixin,
     _ScheduleMixin,
@@ -92,22 +93,7 @@ from .attributes import (
     ASSIGN_ATTR as ASSIGN_ATTR,
 )
 from .attributes import (
-    BODY_ATTR,
-    HEATER_TYPE,
-    HITMP_ATTR,
-    LOTMP_ATTR,
-    MODE_ATTR,
-    OBJTYP_ATTR,
-    PARENT_ATTR,
-    PROPNAME_ATTR,
-    SNAME_ATTR,
-    STATUS_ATTR,
-    STATUS_OFF,
-    STATUS_ON,
-    SUBTYP_ATTR,
-    SYSTEM_TYPE,
-    VER_ATTR,
-    HeaterType,
+    BODY_ATTR as BODY_ATTR,
 )
 from .attributes import (
     BODY_TYPE as BODY_TYPE,
@@ -140,10 +126,19 @@ from .attributes import (
     HEATER_ATTR as HEATER_ATTR,
 )
 from .attributes import (
+    HEATER_TYPE as HEATER_TYPE,
+)
+from .attributes import (
+    HITMP_ATTR as HITMP_ATTR,
+)
+from .attributes import (
     HTMODE_ATTR as HTMODE_ATTR,
 )
 from .attributes import (
     LIGHT_EFFECTS as LIGHT_EFFECTS,
+)
+from .attributes import (
+    LOTMP_ATTR as LOTMP_ATTR,
 )
 from .attributes import (
     MAX_ATTR as MAX_ATTR,
@@ -156,6 +151,19 @@ from .attributes import (
 )
 from .attributes import (
     MINF_ATTR as MINF_ATTR,
+)
+from .attributes import (
+    MODE_ATTR,
+    OBJTYP_ATTR,
+    PARENT_ATTR,
+    PROPNAME_ATTR,
+    SNAME_ATTR,
+    STATUS_ATTR,
+    STATUS_OFF,
+    STATUS_ON,
+    SUBTYP_ATTR,
+    SYSTEM_TYPE,
+    VER_ATTR,
 )
 from .attributes import (
     NULL_OBJNAM as NULL_OBJNAM,
@@ -240,6 +248,9 @@ from .attributes import (
 )
 from .attributes import (
     VALVE_TYPE as VALVE_TYPE,
+)
+from .attributes import (
+    HeaterType as HeaterType,
 )
 from .connection import DEFAULT_TCP_PORT, DEFAULT_WEBSOCKET_PORT, ICConnection, TransportType
 from .exceptions import ICCommandError, ICConnectionError, ICResponseError, ICTimeoutError
@@ -625,6 +636,7 @@ class ICModelController(
     _PumpMixin,
     _BodyMixin,
     _SystemMixin,
+    _HeaterMixin,
     ICBaseController,
 ):
     """Controller that maintains a PoolModel of equipment state."""
@@ -886,73 +898,6 @@ class ICModelController(
         await self._flush_pending_changes()
         return await request.future
 
-    async def set_heat_mode(self, body_objnam: str, mode: HeaterType) -> dict[str, Any]:
-        """Set the heat mode for a body of water.
-
-        Args:
-            body_objnam: Object name of the body (pool or spa)
-            mode: HeaterType enum value
-
-        Returns:
-            Response dictionary
-
-        Example:
-            await controller.set_heat_mode("B1101", HeaterType.HEATER)
-        """
-        return await self._queue_property_change(body_objnam, {MODE_ATTR: str(mode.value)})
-
-    async def set_setpoint(self, body_objnam: str, temperature: int) -> dict[str, Any]:
-        """Set the heating setpoint for a body of water.
-
-        This is the temperature the system will heat UP to.
-        Alias for set_heating_setpoint().
-
-        Args:
-            body_objnam: Object name of the body (pool or spa)
-            temperature: Target heating temperature (units match system config)
-
-        Returns:
-            Response dictionary
-        """
-        return await self._queue_property_change(body_objnam, {LOTMP_ATTR: str(temperature)})
-
-    async def set_heating_setpoint(self, body_objnam: str, temperature: int) -> dict[str, Any]:
-        """Set the heating setpoint for a body of water.
-
-        This is the temperature the system will heat UP to (LOTMP attribute).
-        For the cooling setpoint, use set_cooling_setpoint().
-
-        Args:
-            body_objnam: Object name of the body (pool or spa)
-            temperature: Target heating temperature (units match system config)
-
-        Returns:
-            Response dictionary
-
-        Example:
-            await controller.set_heating_setpoint("B1101", 84)
-        """
-        return await self._queue_property_change(body_objnam, {LOTMP_ATTR: str(temperature)})
-
-    async def set_cooling_setpoint(self, body_objnam: str, temperature: int) -> dict[str, Any]:
-        """Set the cooling setpoint for a body of water.
-
-        This is the temperature the system will cool DOWN to (HITMP attribute).
-        Only relevant for systems with heat pumps or chillers that support cooling.
-        The cooling setpoint must be higher than the heat setpoint.
-
-        Args:
-            body_objnam: Object name of the body (pool or spa)
-            temperature: Target cooling temperature (units match system config)
-
-        Returns:
-            Response dictionary
-
-        Example:
-            await controller.set_cooling_setpoint("B1101", 86)
-        """
-        return await self._queue_property_change(body_objnam, {HITMP_ATTR: str(temperature)})
-
     def _get_attr_as_int(self, objnam: str, attr: str) -> int | None:
         """Get an attribute value as an integer, or None if unavailable."""
         obj = self._model[objnam]
@@ -972,53 +917,6 @@ class ICModelController(
             except (ValueError, TypeError):
                 return None
         return None
-
-    def body_supports_cooling(self, body_objnam: str) -> bool:
-        """Check if a body has a heater that supports cooling.
-
-        UltraTemp heat pumps (SUBTYP="ULTRA") support both heating and cooling.
-        Gas heaters (SUBTYP="HEATER"), solar heaters (SUBTYP="SOLAR"), and
-        generic heaters (SUBTYP="GENERIC") do not support cooling.
-
-        This checks ALL heaters that support this body, not just the currently
-        active one, so it returns True even if the system is currently off or
-        using a different heater.
-
-        Args:
-            body_objnam: Object name of the body (pool or spa)
-
-        Returns:
-            True if any available heater for this body supports cooling
-
-        Example:
-            if controller.body_supports_cooling("B1101"):
-                # Show both heating and cooling setpoints
-                heat_sp = controller.get_body_heating_setpoint("B1101")
-                cool_sp = controller.get_body_cooling_setpoint("B1101")
-        """
-        body = self._model[body_objnam]
-        if not body:
-            _LOGGER.warning("body_supports_cooling: body %s not found", body_objnam)
-            return False
-
-        # Check ALL heaters to see if any support this body AND can cool
-        all_heaters = list(self._model.get_by_type(HEATER_TYPE))
-
-        for heater in all_heaters:
-            # Check if this heater supports this body
-            supported_bodies = heater[BODY_ATTR]
-            if supported_bodies:
-                body_list = supported_bodies.split(" ")
-                if body_objnam in body_list:
-                    # Check if this heater supports cooling via either:
-                    # 1. Subtype being ULTRA (UltraTemp heat pump)
-                    # 2. Having a COOL attribute set to "ON"
-                    has_ultra = heater.subtype == "ULTRA"
-                    has_cool = heater["COOL"] == "ON"
-                    if has_ultra or has_cool:
-                        return True
-
-        return False
 
     # =========================================================================
     # Entity Discovery Helpers (for Home Assistant integration setup)


### PR DESCRIPTION
## Summary

**Step 4 — the final step of the incremental `ICModelController` refactor** (follows #27, #28). Behavior-preserving extraction of the heater/setpoint methods into `_HeaterMixin`, completing the god-class decomposition.

- `_HeaterMixin`: `set_heat_mode`, `set_setpoint`, `set_heating_setpoint`, `set_cooling_setpoint`, `body_supports_cooling`.
- `ICModelController` is now a **16-method core** (connection/coalescing + the cross-cutting `get_all_entities`/`get_featured_entities` aggregators); `controller.py` **1,336 → 1,234**. Across Steps 1–4 the class went from ~1,490 lines / ~82 methods to a thin core composing **10 domain mixins**.

## Behavior preservation
- Public API + `__all__` unchanged; moved methods callable as `controller.<name>(...)` identically (heater methods are text-equivalent to `main`).
- mypy-strict — no `_ModelControllerProtocol` changes needed; **no `# type: ignore` / `# noqa`**.
- Controller-module constant namespace preserved: 5 relocated constants (`BODY_ATTR`, `HEATER_TYPE`, `HITMP_ATTR`, `LOTMP_ATTR`, `HeaterType`) moved into the re-export block; the `test_controller_namespace_compat` guard (added in #28) enforces it.
- **Codex adversarial review: approve.**

## Verification
- `ruff check` / `ruff format --check src tests` → clean
- `mypy src` → Success (27 files)
- `pytest` → **342 passed**

## Follow-up (separate decision)
Moving HCOMBO/heater-mode **semantics** into the library (`heater_uses_mode_control()`, `get_heater_mode_options()`) — the durable fix for the heater/climate churn — is intentionally **not** in this PR. That adds new public API best designed against a settled consumer (PR #46's HCOMBO rework), so it should land together with #46.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
