### PR TITLE
chore: bump version to 0.1.16

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,23 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.1.16] - 2026-05-31
+
+### Added
+
+- Read-only convenience helpers on `ICModelController` (via the domain mixins):
+  - `get_saturation_index()` — surfaces the controller-computed Langelier Saturation Index (`SINDEX`).
+  - `is_heater_ready()` — whether a heater reports `READY=ON`.
+  - `get_sensor_probe_reading()` / `get_sensor_calibration()` — sensor `PROBE` / `CALIB` values.
+  - `get_body_last_temperature()` — a body's last recorded temperature (`LSTTMP`).
+  - `get_heater_for_body()` — resolves a body's assigned heater to its `PoolObject` (null-safe).
+  - `is_schedule_enabled()`, `get_schedule_circuit()`, `get_schedule_start_time()`, `get_schedule_stop_time()`, `get_schedule_days()` — schedule read helpers.
+- New attribute constants `SINDEX_ATTR`, `DAY_ATTR`, and `COOL_ATTR`, exported from the package.
+
+### Changed
+
+- `is_body_cooling()` now reuses `get_heater_for_body()` instead of duplicating the body→heater resolution.
+
 ## [0.1.15] - 2026-02-26
 
 ### Fixed

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "pyintellicenter"
-version = "0.1.15"
+version = "0.1.16"
 description = "Python library for Pentair IntelliCenter pool control systems"
 readme = "README.md"
 license = "MIT"

--- a/src/pyintellicenter/__init__.py
+++ b/src/pyintellicenter/__init__.py
@@ -184,7 +184,7 @@ try:
 except ImportError:
     _DISCOVERY_AVAILABLE = False
 
-__version__ = "0.1.15"
+__version__ = "0.1.16"
 
 __all__ = [
     # Version

--- a/uv.lock
+++ b/uv.lock
@@ -201,7 +201,7 @@ wheels = [
 
 [[package]]
 name = "pyintellicenter"
-version = "0.1.15"
+version = "0.1.16"
 source = { editable = "." }
 dependencies = [
     { name = "orjson" },


### PR DESCRIPTION
Version bump for the read-only helpers landed in #30.

## Changes (no code, metadata only)
- `pyproject.toml`: `0.1.15` → `0.1.16`
- `src/pyintellicenter/__init__.py`: `__version__` → `0.1.16` (kept in sync with pyproject — `tests/test_version.py` enforces this)
- `uv.lock`: refreshed
- `CHANGELOG.md`: new `[0.1.16]` section documenting the helpers + `SINDEX_ATTR`/`DAY_ATTR`/`COOL_ATTR` constants and the `is_body_cooling` de-dup

This is the version the GitHub release (→ PyPI publish) will be cut from.

## Test plan
- `ruff` + `ruff format` + `mypy` clean; **381 tests pass** (incl. the version-consistency guard) on 3.13 and 3.14.