### PR TITLE
Release 0.1.17: SAm light effect (#47) + zero-restart dynamic objects (#42)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+
+- Add the missing `SAMMOD` ("SAm") IntelliBrite light show to `LIGHT_EFFECTS`. When a
+  light's `USE` attribute reported `SAMMOD`, it was absent from the effect map, so
+  downstream consumers (e.g. the Home Assistant integration) resolved the effect to
+  `None`. Verified `SAMMOD` as the IntelliCenter `USE` show code against multiple
+  independent IntelliCenter implementations (intellicenter#47).
+
 ## [0.1.16] - 2026-05-31
 
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,21 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- **Zero-restart dynamic object detection** (issue #42): when IntelliCenter pushes a
+  `NotifyList` for a brand-new object (e.g. a freshly-installed 2nd IntelliChem) that is
+  not yet in the model, `PoolModel.process_updates()` now adds it instead of silently
+  dropping the update — provided the entry carries enough to construct it (`OBJTYP`, and a
+  type tracked by the attribute map). Newly-added objects are surfaced through the normal
+  `updates` dict so existing `on_updated` consumers react to them, and
+  `ICModelController` re-requests attribute monitoring (`RequestParamList`) for them so
+  IntelliCenter starts pushing their state — all without a reconnect or restart.
+  `process_updates()` gains an optional `added_objnams` out-parameter (backward
+  compatible) for callers that want to distinguish additions from updates. Malformed or
+  partial `NotifyList` entries are handled defensively and never crash the hot path.
+  Reported by @bhamiltoncx.
+
 ## [0.1.16] - 2026-05-31
 
 ### Added

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "pyintellicenter"
-version = "0.1.16"
+version = "0.1.17"
 description = "Python library for Pentair IntelliCenter pool control systems"
 readme = "README.md"
 license = "MIT"

--- a/src/pyintellicenter/__init__.py
+++ b/src/pyintellicenter/__init__.py
@@ -184,7 +184,7 @@ try:
 except ImportError:
     _DISCOVERY_AVAILABLE = False
 
-__version__ = "0.1.16"
+__version__ = "0.1.17"
 
 __all__ = [
     # Version

--- a/src/pyintellicenter/attributes/constants.py
+++ b/src/pyintellicenter/attributes/constants.py
@@ -19,13 +19,17 @@ COLOR_EFFECT_SUBTYPES = frozenset(["INTELLI", "MAGIC2", "GLOW"])
 
 # Mapping of IntelliCenter color effect codes to human-readable names
 # Used with the USE attribute on lights with COLOR_EFFECT_SUBTYPES
+# Covers the IntelliBrite light shows followed by the fixed colors.
 LIGHT_EFFECTS: dict[str, str] = {
+    # Light shows
+    "SAMMOD": "SAm",
     "PARTY": "Party Mode",
     "CARIB": "Caribbean",
     "SSET": "Sunset",
     "ROMAN": "Romance",
     "AMERCA": "American",
     "ROYAL": "Royal",
+    # Fixed colors
     "WHITER": "White",
     "REDR": "Red",
     "BLUER": "Blue",

--- a/src/pyintellicenter/controller.py
+++ b/src/pyintellicenter/controller.py
@@ -671,6 +671,10 @@ class ICModelController(
         self._pending_requests: list[_PendingRequest] = []
         self._coalesce_lock = asyncio.Lock()
 
+        # Background tasks that request monitoring for objects added at runtime.
+        # Held in a set so they are not garbage-collected before completing.
+        self._monitor_tasks: set[asyncio.Task[None]] = set()
+
     def __repr__(self) -> str:
         return (
             f"ICModelController(host={self._host!r}, port={self._port}, "
@@ -739,18 +743,78 @@ class ICModelController(
                 _LOGGER.exception("Error processing NotifyList: %s", err)
 
     def _apply_updates(self, changes_as_list: list[ObjectEntry]) -> dict[str, dict[str, Any]]:
-        """Apply updates to the model."""
-        updates = self._model.process_updates(changes_as_list)
+        """Apply updates to the model.
+
+        A NotifyList may introduce a brand-new object (e.g. equipment installed
+        while the connection is live). process_updates() adds such objects to the
+        model and reports their objnams via ``added_objnams``; we then schedule a
+        RequestParamList so IntelliCenter starts pushing their monitored
+        attributes (a newly-added object is not monitored otherwise).
+        """
+        added_objnams: set[str] = set()
+        updates = self._model.process_updates(changes_as_list, added_objnams)
 
         # Update ICSystemInfo if changed
         if self._system_info and self._system_info.objnam in updates:
             self._system_info.update(updates[self._system_info.objnam])
 
-        # Notify callback
+        # Notify callback (newly-added objects are included in updates, so the
+        # existing callback path surfaces them to consumers).
         if updates and self._updated_callback:
             self._updated_callback(self, updates)
 
+        # Start monitoring any newly-added objects. This issues a network request,
+        # so it runs as a background task; _on_notification is a synchronous
+        # callback. If no event loop is running (e.g. direct synchronous calls in
+        # tests) we skip scheduling rather than crash.
+        if added_objnams:
+            try:
+                loop = asyncio.get_running_loop()
+            except RuntimeError:
+                _LOGGER.debug(
+                    "No running loop; skipping monitor request for new objects %s",
+                    added_objnams,
+                )
+            else:
+                task = loop.create_task(self._request_monitoring_for(added_objnams))
+                # Retain a reference so the task is not garbage-collected, and
+                # drop it once done to avoid unbounded growth.
+                self._monitor_tasks.add(task)
+                task.add_done_callback(self._monitor_tasks.discard)
+
         return updates
+
+    async def _request_monitoring_for(self, objnams: set[str]) -> None:
+        """Request attribute monitoring for the given (newly-added) objects.
+
+        Builds the same per-object {objnam, keys} query that start() uses, from
+        the model's attribute map, and sends it in batches bounded by
+        MAX_ATTRIBUTES_PER_QUERY. Errors are logged and swallowed: this runs in a
+        background task off the notification hot path and must not raise.
+        """
+        # Reuse the model's tracking query, filtered to the new objects so we only
+        # (re-)subscribe what is needed.
+        queries = [q for q in self._model.attributes_to_track() if q["objnam"] in objnams]
+        if not queries:
+            return
+
+        batch: list[dict[str, Any]] = []
+        num_attributes = 0
+        try:
+            for items in queries:
+                batch.append(items)
+                num_attributes += len(items["keys"])
+                if num_attributes >= MAX_ATTRIBUTES_PER_QUERY:
+                    res = await self.send_cmd("RequestParamList", {"objectList": batch})
+                    self._apply_updates(res["objectList"])
+                    batch = []
+                    num_attributes = 0
+
+            if batch:
+                res = await self.send_cmd("RequestParamList", {"objectList": batch})
+                self._apply_updates(res["objectList"])
+        except (ICConnectionError, ICCommandError, ICTimeoutError, OSError) as err:
+            _LOGGER.warning("Failed to request monitoring for new objects %s: %s", objnams, err)
 
     # --------------------------------------------------------------------------
     # Request coalescing for convenience methods

--- a/src/pyintellicenter/controller.py
+++ b/src/pyintellicenter/controller.py
@@ -777,20 +777,33 @@ class ICModelController(
                 )
             else:
                 task = loop.create_task(self._request_monitoring_for(added_objnams))
-                # Retain a reference so the task is not garbage-collected, and
-                # drop it once done to avoid unbounded growth.
+                # Retain a reference so the task is not garbage-collected; the
+                # done callback drops it and logs any unexpected failure.
                 self._monitor_tasks.add(task)
-                task.add_done_callback(self._monitor_tasks.discard)
+                task.add_done_callback(self._on_monitor_task_done)
 
         return updates
+
+    def _on_monitor_task_done(self, task: asyncio.Task[None]) -> None:
+        """Discard a finished monitor task and surface any unexpected error.
+
+        Expected connection errors are handled inside the task; this catches
+        anything else (a bug, or a callback raising) so it is logged rather than
+        silently swallowed by asyncio.
+        """
+        self._monitor_tasks.discard(task)
+        if not task.cancelled():
+            exc = task.exception()
+            if exc is not None:
+                _LOGGER.warning("Monitor request for new objects failed: %s", exc)
 
     async def _request_monitoring_for(self, objnams: set[str]) -> None:
         """Request attribute monitoring for the given (newly-added) objects.
 
         Builds the same per-object {objnam, keys} query that start() uses, from
         the model's attribute map, and sends it in batches bounded by
-        MAX_ATTRIBUTES_PER_QUERY. Errors are logged and swallowed: this runs in a
-        background task off the notification hot path and must not raise.
+        MAX_ATTRIBUTES_PER_QUERY. Connection errors are logged and swallowed:
+        this runs in a background task off the notification hot path.
         """
         # Reuse the model's tracking query, filtered to the new objects so we only
         # (re-)subscribe what is needed.
@@ -802,19 +815,36 @@ class ICModelController(
         num_attributes = 0
         try:
             for items in queries:
-                batch.append(items)
-                num_attributes += len(items["keys"])
-                if num_attributes >= MAX_ATTRIBUTES_PER_QUERY:
-                    res = await self.send_cmd("RequestParamList", {"objectList": batch})
-                    self._apply_updates(res["objectList"])
+                keys_len = len(items["keys"])
+                # Flush the current batch before it would exceed the limit (a
+                # single object with more keys than the limit is still sent alone).
+                if batch and num_attributes + keys_len > MAX_ATTRIBUTES_PER_QUERY:
+                    await self._send_monitor_batch(batch)
                     batch = []
                     num_attributes = 0
+                batch.append(items)
+                num_attributes += keys_len
 
             if batch:
-                res = await self.send_cmd("RequestParamList", {"objectList": batch})
-                self._apply_updates(res["objectList"])
+                await self._send_monitor_batch(batch)
         except (ICConnectionError, ICCommandError, ICTimeoutError, OSError) as err:
             _LOGGER.warning("Failed to request monitoring for new objects %s: %s", objnams, err)
+
+    async def _send_monitor_batch(self, batch: list[dict[str, Any]]) -> None:
+        """Send one RequestParamList batch and apply the response.
+
+        Validates the response shape so a malformed reply is logged and skipped
+        rather than crashing the background monitor task.
+        """
+        res = await self.send_cmd("RequestParamList", {"objectList": batch})
+        object_list = res.get("objectList")
+        if not isinstance(object_list, list):
+            _LOGGER.warning(
+                "RequestParamList returned no usable objectList for monitor request: %r",
+                res,
+            )
+            return
+        self._apply_updates(object_list)
 
     # --------------------------------------------------------------------------
     # Request coalescing for convenience methods

--- a/src/pyintellicenter/model.py
+++ b/src/pyintellicenter/model.py
@@ -322,21 +322,77 @@ class PoolModel:
                 query.append({"objnam": pool_obj.objnam, "keys": list(attributes)})
         return query
 
-    def process_updates(self, updates: list[ObjectEntry]) -> dict[str, dict[str, Any]]:
+    def process_updates(
+        self,
+        updates: list[ObjectEntry],
+        added_objnams: set[str] | None = None,
+    ) -> dict[str, dict[str, Any]]:
         """Update the state of the objects in the model.
 
+        Existing objects are updated in place. A NotifyList may also reference an
+        object that is not yet in the model (e.g. equipment installed while the
+        connection is live, without a reconnect). When such an entry carries
+        enough information to construct the object (its params include OBJTYP and
+        its type is tracked by the attribute map) it is added to the model so the
+        new equipment is surfaced without requiring a restart. Entries that are
+        unknown and lack enough information to be constructed are ignored.
+
         Args:
-            updates: List of updates with 'objnam' and 'params' keys
+            updates: List of updates with 'objnam' and 'params' keys.
+            added_objnams: Optional set, populated with the objnams of any objects
+                that were newly added to the model by this call. Callers can use it
+                to react to new equipment (e.g. re-request attribute monitoring).
 
         Returns:
-            Dictionary mapping objnam to their changed attributes
+            Dictionary mapping objnam to their changed attributes. For a newly
+            added object the value is the object's full set of attributes, so the
+            same callback path that fires for updates also fires for additions.
         """
         updated: dict[str, dict[str, Any]] = {}
         for update in updates:
-            objnam = update["objnam"]
+            # Defensive: a malformed NotifyList entry may be missing 'objnam' or
+            # 'params'. This is a protocol hot path, so never let one bad entry
+            # crash processing of the rest.
+            try:
+                objnam = update["objnam"]
+                params = update["params"]
+            except (KeyError, TypeError):
+                _LOGGER.debug("Skipping malformed update entry: %r", update)
+                continue
+
+            # A well-formed entry has a dict of params. Guard against a malformed
+            # params value (e.g. a string) so neither the in-place update nor the
+            # new-object construction below can raise on the protocol hot path.
+            if not isinstance(params, dict):
+                _LOGGER.debug(
+                    "Skipping update for %s: params is not a dict (%r)", objnam, params
+                )
+                continue
+
             pool_obj = self._objects.get(objnam)
             if pool_obj is not None:
-                changed = pool_obj.update(update["params"])
+                changed = pool_obj.update(params)
                 if changed:
                     updated[objnam] = changed
+                continue
+
+            # Unknown objnam: try to add it as a new object. add_object validates
+            # the required OBJTYP attribute and the type-tracking attribute map,
+            # returning None (without storing) when there is not enough
+            # information or the type is not tracked. A non-None result for a
+            # previously-absent objnam means it was added to the model. Pass a
+            # copy because PoolObject consumes the dict (it pops OBJTYP/SUBTYP).
+            new_obj = self.add_object(objnam, dict(params))
+            if new_obj is not None:
+                # Surface the new object's full attribute set through the normal
+                # updates dict so existing callback consumers react to it.
+                # OBJTYP/SUBTYP are stored separately on the object (popped from
+                # properties), so add them back for a coherent change payload.
+                changed = dict(new_obj.properties)
+                changed[OBJTYP_ATTR] = new_obj.objtype
+                if new_obj.subtype is not None:
+                    changed[SUBTYP_ATTR] = new_obj.subtype
+                updated[objnam] = changed
+                if added_objnams is not None:
+                    added_objnams.add(objnam)
         return updated

--- a/src/pyintellicenter/model.py
+++ b/src/pyintellicenter/model.py
@@ -360,13 +360,12 @@ class PoolModel:
                 _LOGGER.debug("Skipping malformed update entry: %r", update)
                 continue
 
-            # A well-formed entry has a dict of params. Guard against a malformed
-            # params value (e.g. a string) so neither the in-place update nor the
-            # new-object construction below can raise on the protocol hot path.
-            if not isinstance(params, dict):
-                _LOGGER.debug(
-                    "Skipping update for %s: params is not a dict (%r)", objnam, params
-                )
+            # A well-formed entry has a string objnam and a dict of params. Guard
+            # against malformed values (a non-string objnam can't be a dict key
+            # and a non-dict params would break update/construction) so neither
+            # the lookup below nor the hot path can raise.
+            if not isinstance(objnam, str) or not isinstance(params, dict):
+                _LOGGER.debug("Skipping update with invalid objnam/params: %r", update)
                 continue
 
             pool_obj = self._objects.get(objnam)

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -28,7 +28,8 @@ def pool_object_light() -> PoolObject:
             SUBTYP_ATTR: "INTELLI",
             SNAME_ATTR: "Pool Light",
             STATUS_ATTR: "OFF",
-            "USE": "SAM",
+            # SAMMOD is the IntelliCenter USE code for the "SAm" light show.
+            "USE": "SAMMOD",
         },
     )
 

--- a/tests/test_controller.py
+++ b/tests/test_controller.py
@@ -583,23 +583,15 @@ class TestICModelController:
         await asyncio.gather(*controller._monitor_tasks)
 
         # A RequestParamList was sent that targets the new object.
-        request_param_calls = [
-            extra for cmd, extra in sent_commands if cmd == "RequestParamList"
-        ]
+        request_param_calls = [extra for cmd, extra in sent_commands if cmd == "RequestParamList"]
         assert request_param_calls
-        targeted = {
-            item["objnam"]
-            for extra in request_param_calls
-            for item in extra["objectList"]
-        }
+        targeted = {item["objnam"] for extra in request_param_calls for item in extra["objectList"]}
         assert "CHM02" in targeted
 
     @pytest.mark.asyncio
     async def test_request_monitoring_for_handles_errors(self, controller, model):
         """_request_monitoring_for swallows connection errors (background task)."""
-        model.add_object(
-            "CHM02", {"OBJTYP": "CHEM", "SUBTYP": "ICHEM", "SNAME": "IntelliChem 2"}
-        )
+        model.add_object("CHM02", {"OBJTYP": "CHEM", "SUBTYP": "ICHEM", "SNAME": "IntelliChem 2"})
         controller.send_cmd = AsyncMock(side_effect=ICConnectionError("boom"))
 
         # Must not raise despite the failing send_cmd.
@@ -611,6 +603,48 @@ class TestICModelController:
         controller.send_cmd = AsyncMock()
         await controller._request_monitoring_for({"DOES_NOT_EXIST"})
         controller.send_cmd.assert_not_called()
+
+    @pytest.mark.asyncio
+    async def test_request_monitoring_for_handles_malformed_response(self, controller, model):
+        """A response missing/!list objectList is skipped, not crashed."""
+        model.add_object("CHM02", {"OBJTYP": "CHEM", "SUBTYP": "ICHEM", "SNAME": "IntelliChem 2"})
+
+        # Missing objectList entirely.
+        controller.send_cmd = AsyncMock(return_value={"response": "200"})
+        await controller._request_monitoring_for({"CHM02"})  # must not raise
+
+        # objectList present but not a list.
+        controller.send_cmd = AsyncMock(return_value={"objectList": "nope"})
+        await controller._request_monitoring_for({"CHM02"})  # must not raise
+
+    @pytest.mark.asyncio
+    async def test_request_monitoring_for_respects_batch_limit(self, controller, monkeypatch):
+        """No single RequestParamList batch exceeds MAX_ATTRIBUTES_PER_QUERY keys."""
+        from pyintellicenter.controller import MAX_ATTRIBUTES_PER_QUERY
+
+        # Craft tracked queries whose combined key count far exceeds the limit
+        # (5 objects x 20 keys = 100 > 50), forcing a split into batches.
+        objnams = {f"OBJ{i}" for i in range(5)}
+        crafted = [{"objnam": f"OBJ{i}", "keys": ["K"] * 20} for i in range(5)]
+        monkeypatch.setattr(controller._model, "attributes_to_track", lambda: crafted)
+
+        batches: list[list[dict]] = []
+
+        async def fake_send_cmd(cmd, extra=None):
+            if cmd == "RequestParamList":
+                batches.append(extra["objectList"])
+            return {"objectList": []}
+
+        controller.send_cmd = AsyncMock(side_effect=fake_send_cmd)
+        await controller._request_monitoring_for(objnams)
+
+        assert len(batches) > 1, "expected the oversized query to split into batches"
+        for batch in batches:
+            total_keys = sum(len(item["keys"]) for item in batch)
+            assert total_keys <= MAX_ATTRIBUTES_PER_QUERY
+        # Every object is still covered exactly once across the batches.
+        covered = [item["objnam"] for batch in batches for item in batch]
+        assert sorted(covered) == sorted(objnams)
 
     @pytest.mark.asyncio
     async def test_set_circuit_state(self, controller):

--- a/tests/test_controller.py
+++ b/tests/test_controller.py
@@ -490,6 +490,128 @@ class TestICModelController:
         assert callback_called
         assert "CIRCUIT1" in received_updates
 
+    def test_on_notification_adds_new_object_and_fires_callback(self, controller, model):
+        """A NotifyList for a brand-new object adds it and fires the callback.
+
+        Covers the zero-restart dynamic-object path (issue #42): an object not
+        already in the model arrives via NotifyList with OBJTYP and is added,
+        then surfaced through the existing updated callback. Called synchronously
+        (no running loop) so the monitor re-request is skipped gracefully.
+        """
+        received_updates = {}
+
+        def update_callback(ctrl, updates):
+            received_updates.update(updates)
+
+        controller.set_updated_callback(update_callback)
+
+        assert model["CHM02"] is None
+
+        msg = {
+            "command": "NotifyList",
+            "objectList": [
+                {
+                    "objnam": "CHM02",
+                    "params": {
+                        "OBJTYP": "CHEM",
+                        "SUBTYP": "ICHEM",
+                        "SNAME": "IntelliChem 2",
+                        "STATUS": "ON",
+                    },
+                }
+            ],
+        }
+        # No event loop running here; must not raise.
+        controller._on_notification(msg)
+
+        # Object added to the model and surfaced to the callback.
+        new_obj = model["CHM02"]
+        assert new_obj is not None
+        assert new_obj.objtype == "CHEM"
+        assert "CHM02" in received_updates
+        assert received_updates["CHM02"]["STATUS"] == "ON"
+
+    def test_on_notification_unknown_object_without_objtyp_no_crash(self, controller, model):
+        """A NotifyList for an unknown objnam lacking OBJTYP is ignored safely."""
+        callback_calls = []
+        controller.set_updated_callback(lambda ctrl, updates: callback_calls.append(updates))
+
+        msg = {
+            "command": "NotifyList",
+            "objectList": [{"objnam": "MYSTERY", "params": {"STATUS": "ON"}}],
+        }
+        controller._on_notification(msg)
+
+        assert model["MYSTERY"] is None
+        # Nothing changed, so the callback should not fire.
+        assert callback_calls == []
+
+    @pytest.mark.asyncio
+    async def test_new_object_triggers_monitoring_request(self, controller, model):
+        """A new object arriving via NotifyList triggers a RequestParamList.
+
+        IntelliCenter does not push attributes for an object that was not part
+        of the initial monitoring request, so the controller must (re-)subscribe
+        the newly-added object. Runs inside an event loop so the background
+        monitor task is scheduled.
+        """
+        sent_commands = []
+
+        async def fake_send_cmd(cmd, extra=None):
+            sent_commands.append((cmd, extra))
+            return {"response": "200", "objectList": []}
+
+        controller.send_cmd = AsyncMock(side_effect=fake_send_cmd)
+
+        msg = {
+            "command": "NotifyList",
+            "objectList": [
+                {
+                    "objnam": "CHM02",
+                    "params": {
+                        "OBJTYP": "CHEM",
+                        "SUBTYP": "ICHEM",
+                        "SNAME": "IntelliChem 2",
+                    },
+                }
+            ],
+        }
+        controller._on_notification(msg)
+
+        # The monitor request runs as a background task; let it run.
+        assert controller._monitor_tasks
+        await asyncio.gather(*controller._monitor_tasks)
+
+        # A RequestParamList was sent that targets the new object.
+        request_param_calls = [
+            extra for cmd, extra in sent_commands if cmd == "RequestParamList"
+        ]
+        assert request_param_calls
+        targeted = {
+            item["objnam"]
+            for extra in request_param_calls
+            for item in extra["objectList"]
+        }
+        assert "CHM02" in targeted
+
+    @pytest.mark.asyncio
+    async def test_request_monitoring_for_handles_errors(self, controller, model):
+        """_request_monitoring_for swallows connection errors (background task)."""
+        model.add_object(
+            "CHM02", {"OBJTYP": "CHEM", "SUBTYP": "ICHEM", "SNAME": "IntelliChem 2"}
+        )
+        controller.send_cmd = AsyncMock(side_effect=ICConnectionError("boom"))
+
+        # Must not raise despite the failing send_cmd.
+        await controller._request_monitoring_for({"CHM02"})
+
+    @pytest.mark.asyncio
+    async def test_request_monitoring_for_no_matching_objects(self, controller):
+        """_request_monitoring_for is a no-op when nothing matches."""
+        controller.send_cmd = AsyncMock()
+        await controller._request_monitoring_for({"DOES_NOT_EXIST"})
+        controller.send_cmd.assert_not_called()
+
     @pytest.mark.asyncio
     async def test_set_circuit_state(self, controller):
         """Test set_circuit_state convenience method."""

--- a/tests/test_controller.py
+++ b/tests/test_controller.py
@@ -1284,6 +1284,24 @@ class TestICModelController:
         """Test get_light_effect returns None when object doesn't exist."""
         assert controller.get_light_effect("NONEXISTENT") is None
 
+    def test_sam_light_show_effect_is_known(self, controller):
+        """Regression test for intellicenter#47: the SAm light show must map.
+
+        IntelliCenter reports the SAm light show as USE=SAMMOD. It was missing
+        from LIGHT_EFFECTS, so consumers resolved the effect name to None.
+        """
+        effects = controller.get_available_light_effects()
+        assert "SAMMOD" in effects
+        assert effects["SAMMOD"] == "SAm"
+
+    def test_get_light_effect_name_resolves_sam(self, controller, model):
+        """A light reporting USE=SAMMOD resolves to the SAm effect name."""
+        model.add_object(
+            "C001",
+            {"OBJTYP": "CIRCUIT", "SUBTYP": "INTELLI", "SNAME": "Light", "USE": "SAMMOD"},
+        )
+        assert controller.get_light_effect_name("C001") == "SAm"
+
 
 class TestRequestCoalescing:
     """Test request coalescing behavior in ICModelController."""

--- a/tests/test_model.py
+++ b/tests/test_model.py
@@ -346,9 +346,7 @@ class TestPoolModel:
         assert changed["CHM02"][SUBTYP_ATTR] == "ICHEM"
         assert added == {"CHM02"}
 
-    def test_pool_model_process_updates_new_object_without_added_set(
-        self, pool_model: PoolModel
-    ):
+    def test_pool_model_process_updates_new_object_without_added_set(self, pool_model: PoolModel):
         """Adding a new object works even when no added_objnams set is passed.
 
         The added_objnams parameter is optional and backward-compatible.

--- a/tests/test_model.py
+++ b/tests/test_model.py
@@ -289,7 +289,11 @@ class TestPoolModel:
         assert changed == {}
 
     def test_pool_model_process_updates_unknown_object(self, pool_model: PoolModel):
-        """Test processing updates for non-existent object."""
+        """Test processing updates for non-existent object without OBJTYP.
+
+        A NotifyList entry for an unknown objnam that lacks enough information
+        to construct the object (no OBJTYP) is ignored safely.
+        """
         updates = [
             {
                 "objnam": "UNKNOWN",
@@ -297,9 +301,131 @@ class TestPoolModel:
             },
         ]
 
-        changed = pool_model.process_updates(updates)
+        added: set[str] = set()
+        changed = pool_model.process_updates(updates, added)
 
         assert changed == {}
+        assert added == set()
+        assert pool_model["UNKNOWN"] is None
+        assert pool_model.num_objects == 4  # unchanged
+
+    def test_pool_model_process_updates_adds_new_object(self, pool_model: PoolModel):
+        """A NotifyList for a brand-new object (with OBJTYP) adds it to the model.
+
+        Simulates a freshly-installed 2nd IntelliChem appearing via NotifyList
+        without a reconnect (issue #42).
+        """
+        original_count = pool_model.num_objects
+        updates = [
+            {
+                "objnam": "CHM02",
+                "params": {
+                    OBJTYP_ATTR: "CHEM",
+                    SUBTYP_ATTR: "ICHEM",
+                    SNAME_ATTR: "IntelliChem 2",
+                    STATUS_ATTR: "ON",
+                },
+            },
+        ]
+
+        added: set[str] = set()
+        changed = pool_model.process_updates(updates, added)
+
+        # Object is now in the model.
+        new_obj = pool_model["CHM02"]
+        assert new_obj is not None
+        assert new_obj.objtype == "CHEM"
+        assert new_obj.subtype == "ICHEM"
+        assert new_obj.sname == "IntelliChem 2"
+        assert pool_model.num_objects == original_count + 1
+
+        # It is surfaced as a change and reported as newly added.
+        assert "CHM02" in changed
+        assert changed["CHM02"][STATUS_ATTR] == "ON"
+        assert changed["CHM02"][OBJTYP_ATTR] == "CHEM"
+        assert changed["CHM02"][SUBTYP_ATTR] == "ICHEM"
+        assert added == {"CHM02"}
+
+    def test_pool_model_process_updates_new_object_without_added_set(
+        self, pool_model: PoolModel
+    ):
+        """Adding a new object works even when no added_objnams set is passed.
+
+        The added_objnams parameter is optional and backward-compatible.
+        """
+        updates = [
+            {
+                "objnam": "CHM02",
+                "params": {OBJTYP_ATTR: "CHEM", SUBTYP_ATTR: "ICHEM"},
+            },
+        ]
+
+        changed = pool_model.process_updates(updates)
+
+        assert pool_model["CHM02"] is not None
+        assert "CHM02" in changed
+
+    def test_pool_model_process_updates_new_object_untracked_type(self):
+        """A new object whose type is not tracked is not added or surfaced."""
+        model = PoolModel(attribute_map={CIRCUIT_TYPE: {STATUS_ATTR}})
+        updates = [
+            {
+                "objnam": "PUMP9",
+                "params": {OBJTYP_ATTR: PUMP_TYPE, STATUS_ATTR: "10"},
+            },
+        ]
+
+        added: set[str] = set()
+        changed = model.process_updates(updates, added)
+
+        assert changed == {}
+        assert added == set()
+        assert model["PUMP9"] is None
+        assert model.num_objects == 0
+
+    def test_pool_model_process_updates_mixed_new_and_existing(self, pool_model: PoolModel):
+        """A single NotifyList can update an existing object and add a new one."""
+        updates = [
+            {"objnam": "LIGHT1", "params": {STATUS_ATTR: "ON"}},
+            {
+                "objnam": "CHM02",
+                "params": {OBJTYP_ATTR: "CHEM", SUBTYP_ATTR: "ICHEM"},
+            },
+        ]
+
+        added: set[str] = set()
+        changed = pool_model.process_updates(updates, added)
+
+        assert pool_model["LIGHT1"].status == "ON"
+        assert pool_model["CHM02"] is not None
+        assert "LIGHT1" in changed
+        assert "CHM02" in changed
+        assert added == {"CHM02"}
+
+    def test_pool_model_process_updates_malformed_entries_safe(self, pool_model: PoolModel):
+        """Malformed NotifyList entries never crash and don't corrupt the model."""
+        original_count = pool_model.num_objects
+        # Deliberately malformed entries (wrong shape/type) to exercise the
+        # protocol hot-path robustness. Typed as list[Any] because these
+        # intentionally violate the ObjectEntry contract.
+        updates: list[Any] = [
+            {"params": {STATUS_ATTR: "ON"}},  # missing 'objnam'
+            {"objnam": "LIGHT1"},  # missing 'params'
+            "not-a-dict",  # wrong type entirely
+            {"objnam": "NEWBAD", "params": "garbage"},  # params not a dict
+            {"objnam": "LIGHT1", "params": {STATUS_ATTR: "ON"}},  # valid
+        ]
+
+        added: set[str] = set()
+        # Must not raise.
+        changed = pool_model.process_updates(updates, added)
+
+        # The one valid entry still applied; model not corrupted.
+        assert pool_model["LIGHT1"].status == "ON"
+        assert "LIGHT1" in changed
+        assert added == set()
+        assert pool_model["NEWBAD"] is None
+        assert pool_model.num_objects == original_count
 
     def test_pool_model_attributes_to_track(self, pool_model: PoolModel):
         """Test generating attribute tracking queries."""


### PR DESCRIPTION
## Summary
pyintellicenter **0.1.17** — bundles two fixes for the Home Assistant integration.

### Added — Zero-restart dynamic object detection (intellicenter#42, @bhamiltoncx)
`PoolModel.process_updates()` now adds brand-new objects announced via `NotifyList` (when the entry carries `OBJTYP` and a tracked type) instead of dropping them. New objects surface through the normal `updates` dict so `on_updated` fires, and `ICModelController` re-requests attribute monitoring (`RequestParamList`) for them — so newly-installed equipment (e.g. a 2nd IntelliChem) appears without a reconnect or HA restart. Defensive on the protocol hot path; the `added_objnams` out-param is optional/backward-compatible.

### Fixed — IntelliBrite "SAm" effect (intellicenter#47, @CrewDawg72)
Added the missing `SAMMOD`→"SAm" show to `LIGHT_EFFECTS` (verified against multiple independent IntelliCenter implementations). Also corrected a stale test fixture using an unmapped `USE="SAM"`.

## Test plan
- `uv run pytest` → **395 passed** (10 new dynamic-object tests, 2 SAm effect tests, 2 monitoring-robustness tests)
- `uv run ruff check` + `ruff format --check` → clean
- `uv run mypy src` → only the 5 pre-existing import-stub errors (zeroconf/orjson); no new
- Reviewed: code-simplifier (no changes needed) + Codex adversarial review — batch-limit and malformed-response robustness findings folded in

Closes the library side of intellicenter#42 and intellicenter#47. The integration pin bump to `>=0.1.17` + entity wiring follows in the integration repo.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
