### PR TITLE
fix: ICModelController no longer abstract to downstream type-checkers (#35)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,32 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.1.19] - 2026-06-01
+
+### Fixed
+
+- **Typing: `ICModelController` no longer appears abstract to downstream
+  type-checkers** (issue #35). The domain mixins reached their host-class members
+  through a `TYPE_CHECKING`-only `typing.Protocol` whose empty-bodied members are
+  *implicitly abstract*. Because that protocol preceded the concrete
+  `ICBaseController` in `ICModelController`'s MRO, `mypy` in consumers resolved
+  `system_info` / `send_cmd` / `_system_info` to the abstract protocol and rejected
+  `ICModelController(...)` with `[abstract]` — even though the runtime class is
+  fully concrete. The mixins now inherit a non-abstract `TYPE_CHECKING`-only stub
+  base (`_MixinBase`) instead, so downstream projects can type-check fully against
+  the library's public API and no longer need a `follow_imports = skip` boundary
+  for `pyintellicenter.*`. Runtime behavior is unchanged (`_MixinBase` is plain
+  `object` at runtime, so `ICModelController`'s MRO is identical). A regression
+  test type-checks a consumer that instantiates `ICModelController`.
+
+## [0.1.18] - 2026-06-01
+
+### Added
+
+- Promote the SYSTEM object's `SERVICE` attribute (operating mode: `AUTO` /
+  `SERVICE` / `TIMEOUT`) to a named, exported constant `SERVICE_ATTR`, matching
+  `MODE_ATTR` / `VACFLO_ATTR` / `VER_ATTR` (#36).
+
 ## [0.1.17] - 2026-06-01
 
 ### Added
@@ -480,7 +506,10 @@ First stable release of pyintellicenter.
 - `orjson` for fast JSON serialization
 - Python 3.11+ required
 
-[Unreleased]: https://github.com/joyfulhouse/pyintellicenter/compare/v0.1.11...HEAD
+[Unreleased]: https://github.com/joyfulhouse/pyintellicenter/compare/v0.1.19...HEAD
+[0.1.19]: https://github.com/joyfulhouse/pyintellicenter/compare/v0.1.18...v0.1.19
+[0.1.18]: https://github.com/joyfulhouse/pyintellicenter/compare/v0.1.17...v0.1.18
+[0.1.17]: https://github.com/joyfulhouse/pyintellicenter/compare/v0.1.16...v0.1.17
 [0.1.11]: https://github.com/joyfulhouse/pyintellicenter/compare/v0.1.10...v0.1.11
 [0.1.10]: https://github.com/joyfulhouse/pyintellicenter/compare/v0.1.9...v0.1.10
 [0.1.9]: https://github.com/joyfulhouse/pyintellicenter/compare/v0.1.8...v0.1.9

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "pyintellicenter"
-version = "0.1.18"
+version = "0.1.19"
 description = "Python library for Pentair IntelliCenter pool control systems"
 readme = "README.md"
 license = "MIT"

--- a/src/pyintellicenter/__init__.py
+++ b/src/pyintellicenter/__init__.py
@@ -185,7 +185,7 @@ try:
 except ImportError:
     _DISCOVERY_AVAILABLE = False
 
-__version__ = "0.1.18"
+__version__ = "0.1.19"
 
 __all__ = [
     # Version

--- a/src/pyintellicenter/_mixins/_base.py
+++ b/src/pyintellicenter/_mixins/_base.py
@@ -1,59 +1,70 @@
 """Shared typing support for ``ICModelController`` mixins.
 
 The mixins in this package are composed into :class:`ICModelController` and rely
-on members defined by the host class (the model, attribute coercion helpers, and
-the request-coalescing entry point). To keep ``mypy`` strict happy without any
-runtime behavior change, each mixin inherits :class:`_ModelControllerProtocol`
-*only* under ``TYPE_CHECKING``. At runtime the mixins remain plain ``object``
-subclasses, so the method-resolution order of ``ICModelController`` is unchanged.
+on members defined by the host class (the model, attribute coercion helpers, the
+request-coalescing entry point, and the connection-level ``send_cmd`` /
+``system_info``). To give ``mypy`` strict visibility of those members without any
+runtime behavior change, each mixin inherits :data:`_MixinBase`.
+
+At runtime ``_MixinBase`` is plain ``object``, so the method-resolution order and
+behavior of ``ICModelController`` are completely unchanged. Under ``TYPE_CHECKING``
+it is a stub class declaring the host-class members the mixins use.
+
+The stub is deliberately a plain class -- **not** a :class:`typing.Protocol`. A
+``Protocol``'s empty-bodied members are *implicitly abstract*; because the mixins
+(and therefore this base) precede the concrete ``ICBaseController`` in the MRO,
+that abstractness leaked out to downstream type-checkers, which then rejected
+``ICModelController(...)`` as ``[abstract]`` even though the runtime class is
+fully concrete (issue #35). Giving the stub concrete (never-executed) bodies
+keeps it non-abstract while still resolving the members for the mixin bodies.
 """
 
 from __future__ import annotations
 
-from typing import TYPE_CHECKING, Any, Protocol
+from typing import TYPE_CHECKING, Any
 
 if TYPE_CHECKING:
     from ..controller import ICSystemInfo
     from ..model import PoolModel
 
+    class _MixinBase:
+        """Static-only view of the ``ICModelController`` members used by mixins.
 
-class _ModelControllerProtocol(Protocol):
-    """Structural declaration of the host-class members used by the mixins.
+        Exists only under ``TYPE_CHECKING``; at runtime the mixins subclass
+        ``object`` (see the ``else`` branch below), so ``ICModelController``'s MRO
+        and behavior are unchanged. Every member carries a concrete body so the
+        class is not abstract -- this is what keeps ``ICModelController``
+        instantiable for downstream type-checkers. Signatures mirror the concrete
+        implementations on ``ICBaseController`` / ``ICModelController`` exactly so
+        no incompatible-base errors arise when they are combined. The bodies are
+        never executed (the real implementations win at runtime).
+        """
 
-    This protocol is used purely for static type checking; it is never
-    instantiated and adds no runtime cost.
-    """
+        _model: PoolModel
+        _system_info: ICSystemInfo | None
 
-    _model: PoolModel
-    _system_info: ICSystemInfo | None
+        @property
+        def system_info(self) -> ICSystemInfo | None:
+            """Return cached system information (provided by ``ICBaseController``)."""
+            raise NotImplementedError
 
-    @property
-    def system_info(self) -> ICSystemInfo | None:
-        """Return cached system information."""
-        ...
+        def _get_attr_as_int(self, objnam: str, attr: str) -> int | None:
+            """Return an attribute value coerced to ``int`` or ``None``."""
+            raise NotImplementedError
 
-    def _get_attr_as_int(self, objnam: str, attr: str) -> int | None:
-        """Return an attribute value coerced to ``int`` or ``None``."""
-        ...
+        def _get_attr_as_float(self, objnam: str, attr: str) -> float | None:
+            """Return an attribute value coerced to ``float`` or ``None``."""
+            raise NotImplementedError
 
-    def _get_attr_as_float(self, objnam: str, attr: str) -> float | None:
-        """Return an attribute value coerced to ``float`` or ``None``."""
-        ...
+        async def _queue_property_change(
+            self, objnam: str, changes: dict[str, str]
+        ) -> dict[str, Any]:
+            """Queue a coalesced property change and return the response."""
+            raise NotImplementedError
 
-    async def _queue_property_change(self, objnam: str, changes: dict[str, str]) -> dict[str, Any]:
-        """Queue a coalesced property change and return the response."""
-        ...
+        async def send_cmd(self, cmd: str, extra: dict[str, Any] | None = None) -> dict[str, Any]:
+            """Send a command and return the response (provided by ``ICBaseController``)."""
+            raise NotImplementedError
 
-    async def send_cmd(self, cmd: str, extra: dict[str, Any] | None = None) -> dict[str, Any]:
-        """Send a command and return the response."""
-        ...
-
-
-# Base class for the domain mixins. Under static type checking the mixins inherit
-# the protocol above so ``mypy`` can resolve the host-class members they use; at
-# runtime they inherit plain ``object`` so ``ICModelController``'s method
-# resolution order and behavior are completely unchanged.
-if TYPE_CHECKING:
-    _MixinBase = _ModelControllerProtocol
 else:
     _MixinBase = object

--- a/tests/test_typing_public_api.py
+++ b/tests/test_typing_public_api.py
@@ -1,0 +1,75 @@
+"""Guard the public typing contract of ``ICModelController`` for consumers.
+
+``ICModelController`` composes its domain mixins (``_mixins/``) *before* the
+concrete ``ICBaseController`` in its base list. The mixins reach host-class
+members (``send_cmd``, ``system_info``, ``_system_info``, the coercion helpers,
+the request-coalescing entry point) through a ``TYPE_CHECKING``-only base defined
+in ``_mixins/_base.py``.
+
+If that base is an abstract ``typing.Protocol``, its empty-bodied members are
+*implicitly abstract*, and because the base precedes ``ICBaseController`` in the
+MRO that abstractness leaks out to **downstream** type-checkers -- they then
+reject ``ICModelController(...)`` with ``[abstract]`` even though the runtime
+class is perfectly concrete (see issue #35). The library's own ``mypy src`` does
+*not* catch this, because nothing in ``src/`` instantiates the class outside
+docstrings.
+
+This test pins the contract from a consumer's perspective: a standalone module
+that instantiates ``ICModelController`` must type-check cleanly.
+"""
+
+from __future__ import annotations
+
+import subprocess
+import sys
+import textwrap
+from pathlib import Path
+
+import pytest
+
+# mypy is a dev/test dependency; skip cleanly if a runtime-only env lacks it.
+pytest.importorskip("mypy")
+
+_REPO_ROOT = Path(__file__).resolve().parent.parent
+
+_CONSUMER_SOURCE = textwrap.dedent(
+    """\
+    \"\"\"Downstream-style consumer; must type-check without [abstract] errors.\"\"\"
+    from __future__ import annotations
+
+    from pyintellicenter import ICModelController, PoolModel
+
+
+    def make_controller() -> ICModelController:
+        return ICModelController("192.168.1.100", PoolModel())
+    """
+)
+
+
+def test_model_controller_instantiable_for_consumers(tmp_path: Path) -> None:
+    """A consumer instantiating ``ICModelController`` must pass mypy (issue #35)."""
+    consumer = tmp_path / "consumer.py"
+    consumer.write_text(_CONSUMER_SOURCE)
+
+    result = subprocess.run(
+        [
+            sys.executable,
+            "-m",
+            "mypy",
+            "--no-incremental",
+            "--cache-dir",
+            str(tmp_path / ".mypy_cache"),
+            str(consumer),
+        ],
+        cwd=_REPO_ROOT,
+        capture_output=True,
+        text=True,
+        check=False,
+    )
+
+    output = result.stdout + result.stderr
+    assert result.returncode == 0, (
+        "Downstream instantiation of ICModelController failed mypy -- the mixin "
+        "typing scaffolding is leaking abstractness (issue #35).\n\n" + output
+    )
+    assert "[abstract]" not in output, output

--- a/tests/test_typing_public_api.py
+++ b/tests/test_typing_public_api.py
@@ -30,6 +30,12 @@ import pytest
 # mypy is a dev/test dependency; skip cleanly if a runtime-only env lacks it.
 pytest.importorskip("mypy")
 
+# Precondition: this guards the #35 contract only when ``pyintellicenter`` is
+# importable by mypy (installed, with its ``py.typed`` marker) so mypy follows the
+# consumer's import into the real package -- true in dev/CI where it is installed
+# editable. Run against an uninstalled checkout, mypy would fail with "cannot find
+# module" instead of "[abstract]": still a failure, but not the one this guards.
+
 _REPO_ROOT = Path(__file__).resolve().parent.parent
 
 _CONSUMER_SOURCE = textwrap.dedent(

--- a/uv.lock
+++ b/uv.lock
@@ -201,7 +201,7 @@ wheels = [
 
 [[package]]
 name = "pyintellicenter"
-version = "0.1.18"
+version = "0.1.19"
 source = { editable = "." }
 dependencies = [
     { name = "orjson" },


### PR DESCRIPTION
Closes #35.

## Problem
`ICModelController` composes its 10 domain mixins **before** the concrete `ICBaseController` in its base list. The mixins reached host-class members (`system_info`, `send_cmd`, `_system_info`, the coercion helpers, the request-coalescing entry point) through a `TYPE_CHECKING`-only `typing.Protocol` (`_ModelControllerProtocol`) whose empty-bodied members are **implicitly abstract**.

Because that protocol preceded `ICBaseController` in the MRO, `mypy` in **downstream consumers** resolved `system_info` / `send_cmd` / `_system_info` to the abstract protocol and rejected instantiation:

```
error: Cannot instantiate abstract class "ICModelController" with abstract attributes
"_system_info", "send_cmd" and "system_info"  [abstract]
```

Runtime was always fine — this was a typing-only artifact of the mixin refactor (#27–#29). The library's own `mypy src` did **not** catch it because nothing in `src/` instantiates the class outside docstrings. The `joyfulhouse/intellicenter` integration kept `follow_imports = skip` for `pyintellicenter.*` **solely** because of this.

## Fix
Replace the abstract `Protocol` with a non-abstract, `TYPE_CHECKING`-only `_MixinBase` stub (`_mixins/_base.py`):
- concrete `raise NotImplementedError` bodies (never executed) → members are **not** abstract;
- `system_info` kept as a `@property` to match `ICBaseController`'s read-only semantics;
- signatures mirror `ICBaseController` exactly, so no incompatible-base errors;
- runtime is unchanged (`_MixinBase = object`), so `ICModelController`'s MRO and behavior are byte-for-byte identical.

Downstream projects can now type-check fully against the public API and drop their `follow_imports = skip` boundary.

## Regression guard
`tests/test_typing_public_api.py` runs `mypy` on a consumer that instantiates `ICModelController` and asserts no `[abstract]` error. **RED before the fix, GREEN after.**

## Verification
- new regression test passes; `mypy src` stays clean (no incompatible-base / empty-body errors)
- `ruff check` + `ruff format --check` clean
- **401 tests pass**

## Release
Bumps `0.1.18 → 0.1.19` (pyproject + `__version__` + `uv.lock`) and adds a `[0.1.19]` changelog entry. Also documents the previously-undocumented `[0.1.18]` `SERVICE_ATTR` release and restores the top changelog compare-links.

After this merges + releases to PyPI, the integration can drop its `[mypy-pyintellicenter.*] follow_imports = skip` block and bump its pin to `>=0.1.19`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)