### PR TITLE
docs: add GitHub Sponsors + Ko-fi funding links

### DIFF
--- a/.github/FUNDING.yml
+++ b/.github/FUNDING.yml
@@ -1,0 +1,3 @@
+# These are supported funding model platforms
+github: btli
+ko_fi: bryanli

--- a/README.md
+++ b/README.md
@@ -4,6 +4,8 @@
 [![Python Versions](https://img.shields.io/pypi/pyversions/pyintellicenter.svg)](https://pypi.org/project/pyintellicenter/)
 [![Tests](https://github.com/joyfulhouse/pyintellicenter/actions/workflows/test.yml/badge.svg)](https://github.com/joyfulhouse/pyintellicenter/actions/workflows/test.yml)
 [![License: MIT](https://img.shields.io/badge/License-MIT-yellow.svg)](https://opensource.org/licenses/MIT)
+[![GitHub Sponsors](https://img.shields.io/badge/Sponsor-GitHub-EA4AAA.svg?logo=githubsponsors&logoColor=white)](https://github.com/sponsors/btli)
+[![Ko-fi](https://img.shields.io/badge/Ko--fi-support-FF5E5B.svg?logo=ko-fi&logoColor=white)](https://ko-fi.com/bryanli)
 
 Python library for communicating with Pentair IntelliCenter pool control systems over local network.
 
@@ -565,6 +567,12 @@ uv run mypy src/pyintellicenter
 # Full validation
 uv run ruff check --fix . && uv run ruff format . && uv run mypy src/pyintellicenter && uv run pytest tests/
 ```
+
+## Support Development
+
+This library powers the [Home Assistant IntelliCenter integration](https://github.com/joyfulhouse/intellicenter) and is maintained in my spare time, with real hardware and tooling costs behind every release. If it's useful to you, consider sponsoring the project or leaving a tip — it's genuinely appreciated.
+
+[![GitHub Sponsors](https://img.shields.io/badge/Sponsor-GitHub-EA4AAA.svg?logo=githubsponsors&logoColor=white)](https://github.com/sponsors/btli) [![Ko-fi](https://img.shields.io/badge/Ko--fi-support-FF5E5B.svg?logo=ko-fi&logoColor=white)](https://ko-fi.com/bryanli)
 
 ## License
 


### PR DESCRIPTION
Mirrors the funding setup from [joyfulhouse/intellicenter](https://github.com/joyfulhouse/intellicenter) (PR #70) so both repos surface the same supporter options.

## Changes
- **`.github/FUNDING.yml`** — `github: btli` + `ko_fi: bryanli` → native repo Sponsor button.
- **README** — GitHub Sponsors + Ko-fi badges in the header row, and a short **Support Development** section before the license (matching the flat badge style used here).

Both platforms are **0% platform fee**. GitHub Sponsors is enabled (`hasSponsorsListing: true`); Ko-fi is `ko-fi.com/bryanli`.

Docs-only; no code change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)