### PR TITLE
fix: detect dead connections (WS close, keepalive timeout) and reconnect reliably

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,43 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+
+- **Dead-link detection: silent connection freezes now trigger the disconnect
+  path and reconnection.** Three connection-layer gaps could leave a controller
+  "connected" with frozen state indefinitely (field evidence: 22 hours of
+  stale-but-available Home Assistant entities until a manual restart):
+  - `ICWebSocketTransport._reader_loop` only caught `OSError`/`ConnectionError`,
+    but the websockets library raises `ConnectionClosed` — a
+    `WebSocketException`, *not* an `OSError` — on abnormal closes, so the
+    reader task died without running the disconnect path. A clean server-side
+    close ends the iteration with no exception at all and likewise never ran
+    the disconnect path. Both now invoke `_handle_disconnect` (exactly once;
+    cancellation by a deliberate `close()`/`aclose()` still does not).
+  - `ICConnection._keepalive_loop` caught `TimeoutError`, but `send_request`
+    raises `ICTimeoutError`, which is an `ICError`, not a `TimeoutError` — so a
+    keepalive timeout killed the keepalive task with an unretrieved exception
+    ("Task exception was never retrieved" in consumer logs).
+  - Even when the keepalive loop did catch a failure it only logged and
+    exited — detection without recovery. A failed keepalive now tears down the
+    dead connection and fires the disconnect callback (at most once per
+    connection, even if the transport's own teardown races it) so
+    `ICConnectionHandler`'s reconnect logic takes over. An `ICResponseError`
+    to a keepalive proves the link is alive, so probing continues instead
+    (previously it killed the keepalive task too).
+  - `ICConnectionHandler._starter` — the reconnect retry loop itself — had the
+    same class confusion: it caught `TimeoutError` but not `ICTimeoutError`,
+    so a request-level timeout during a reconnect attempt ended reconnection
+    permanently. It now retries.
+  - WebSocket `send_request` now translates send failures on a dead socket
+    (`ConnectionClosed` from `ws.send()`) into `ICConnectionError` instead of
+    leaking websockets exceptions to callers.
+  - `ICConnectionHandler._on_disconnect` no longer spawns a second concurrent
+    reconnect loop when multiple disconnect paths fire for the same dead
+    connection.
+  - The TCP transport needed no reader-side change (asyncio guarantees
+    `connection_lost`); it shares the fixed keepalive loop.
+
 ## [0.1.19] - 2026-06-01
 
 ### Fixed

--- a/src/pyintellicenter/connection.py
+++ b/src/pyintellicenter/connection.py
@@ -27,6 +27,7 @@ import logging
 from typing import TYPE_CHECKING, Any, Literal, Protocol, runtime_checkable
 
 import orjson
+from websockets.exceptions import WebSocketException
 
 from .exceptions import ICConnectionError, ICResponseError, ICTimeoutError
 
@@ -44,6 +45,7 @@ DEFAULT_TCP_PORT = 6681
 DEFAULT_WEBSOCKET_PORT = 6680
 RESPONSE_TIMEOUT = 30.0  # seconds to wait for a response
 KEEPALIVE_INTERVAL = 90.0  # seconds between keepalive requests
+KEEPALIVE_TIMEOUT = 10.0  # seconds to wait for a keepalive response
 CONNECTION_TIMEOUT = 10.0  # seconds to wait for initial connection
 MAX_BUFFER_SIZE = 1024 * 1024  # 1MB max buffer to prevent DoS
 DEFAULT_NOTIFICATION_QUEUE_SIZE = 100  # max queued notifications
@@ -404,6 +406,9 @@ class ICWebSocketTransport(ICRequestMixin, ICNotificationMixin):
         self._ws: Any = None  # websockets.WebSocketClientProtocol
         self._connected = False
 
+        # Ensures the disconnect path runs at most once per connection
+        self._disconnect_handled = False
+
         # Reader task for incoming messages
         self._reader_task: asyncio.Task[None] | None = None
 
@@ -431,6 +436,7 @@ class ICWebSocketTransport(ICRequestMixin, ICNotificationMixin):
                 timeout=CONNECTION_TIMEOUT,
             )
             self._connected = True
+            self._disconnect_handled = False
             self._message_id = 0
             _LOGGER.debug("WebSocket connected to IntelliCenter at %s:%s", host, port)
 
@@ -449,7 +455,20 @@ class ICWebSocketTransport(ICRequestMixin, ICNotificationMixin):
             raise ICConnectionError(f"WebSocket connection failed: {err}") from err
 
     async def _reader_loop(self) -> None:
-        """Read messages from WebSocket and dispatch them."""
+        """Read messages from WebSocket and dispatch them.
+
+        The websockets iterator ends in one of three ways, and all but
+        cancellation mean the connection is no longer being serviced:
+
+        - the server closes cleanly: iteration ends without an exception
+        - the link dies: ``ConnectionClosed`` (a ``WebSocketException``,
+          *not* an ``OSError``/``ConnectionError``) or an OS-level error
+        - the task is cancelled by a deliberate ``close()``/``aclose()``
+
+        The first two must run the disconnect path so the disconnect
+        callback fires and reconnection logic can take over.
+        """
+        exc: Exception | None = None
         try:
             async for message in self._ws:
                 data = message if isinstance(message, bytes) else message.encode()
@@ -462,14 +481,24 @@ class ICWebSocketTransport(ICRequestMixin, ICNotificationMixin):
 
                 self._dispatch_message(msg)
 
+            _LOGGER.debug("WebSocket closed by server")
+
         except asyncio.CancelledError:
+            # Deliberate close()/aclose(): not a link failure.
             _LOGGER.debug("WebSocket reader cancelled")
-        except (OSError, ConnectionError) as err:
+            return
+        except (WebSocketException, OSError, ConnectionError) as err:
             _LOGGER.debug("WebSocket reader error: %s", err)
-            self._handle_disconnect(err)
+            exc = err
+
+        self._handle_disconnect(exc)
 
     def _handle_disconnect(self, exc: Exception | None) -> None:
-        """Handle disconnection."""
+        """Handle disconnection, firing the disconnect callback exactly once."""
+        if self._disconnect_handled:
+            return
+        self._disconnect_handled = True
+
         self._connected = False
         self._ws = None
 
@@ -524,6 +553,12 @@ class ICWebSocketTransport(ICRequestMixin, ICNotificationMixin):
         except TimeoutError as err:
             _LOGGER.error("Request %s timed out after %ss", command, request_timeout)
             raise ICTimeoutError(f"Request {command} timed out after {request_timeout}s") from err
+
+        except (WebSocketException, OSError, ConnectionError) as err:
+            # ws.send() raises ConnectionClosed (a WebSocketException) on a
+            # dead socket; surface it as the library's connection error.
+            _LOGGER.error("Request %s failed - connection lost: %s", command, err)
+            raise ICConnectionError(f"Connection lost during request {command}: {err}") from err
 
         finally:
             self._clear_pending_request()
@@ -629,6 +664,10 @@ class ICConnection:
         # Keepalive task
         self._keepalive_task: asyncio.Task[None] | None = None
 
+        # Ensures the disconnect callback fires at most once per connection
+        # (the keepalive teardown and the transport's own notification can race)
+        self._disconnect_dispatched = False
+
     def __repr__(self) -> str:
         """Return a detailed string representation for debugging."""
         return (
@@ -685,8 +724,31 @@ class ICConnection:
             self._keepalive_task.cancel()
             self._keepalive_task = None
 
+        self._dispatch_disconnect(exc)
+
+    def _dispatch_disconnect(self, exc: Exception | None) -> None:
+        """Invoke the user disconnect callback at most once per connection."""
+        if self._disconnect_dispatched:
+            return
+        self._disconnect_dispatched = True
+
         if self._disconnect_callback:
             self._disconnect_callback(exc)
+
+    def _abort_connection(self, exc: Exception | None) -> None:
+        """Tear down a connection whose link is dead and run the disconnect path.
+
+        Used when a failure is detected outside the transport's own machinery
+        (e.g. a keepalive timeout on a half-open connection). Detaches the
+        transport's disconnect callback first so the transport's own teardown
+        (e.g. TCP connection_lost after close()) cannot fire it again later.
+        """
+        protocol, self._protocol = self._protocol, None
+        if protocol is not None:
+            protocol._disconnect_callback = None
+            protocol.close()
+
+        self._dispatch_disconnect(exc)
 
     async def connect(self) -> None:
         """Establish connection to IntelliCenter.
@@ -703,6 +765,9 @@ class ICConnection:
             await self._connect_websocket()
         else:
             await self._connect_tcp()
+
+        # Fresh connection - its disconnect may dispatch (again)
+        self._disconnect_dispatched = False
 
         # Start keepalive task
         self._keepalive_task = asyncio.create_task(self._keepalive_loop())
@@ -803,28 +868,45 @@ class ICConnection:
             )
 
     async def _keepalive_loop(self) -> None:
-        """Send periodic keepalive requests to maintain connection health."""
+        """Send periodic keepalive requests to maintain connection health.
+
+        A keepalive failing with a timeout or connection error means the
+        link is dead even though the transport still looks "connected"
+        (half-open connection or unresponsive server). Detection alone is
+        not enough: the connection must be torn down so the disconnect
+        callback fires and reconnection logic can take over - otherwise it
+        stays frozen forever.
+
+        Note: send_request raises ICTimeoutError (an ICError, not a
+        TimeoutError) on timeout, so both are handled explicitly here.
+        """
         try:
             while self.connected:
                 await asyncio.sleep(self._keepalive_interval)
 
                 if not self.connected:
-                    break
+                    return
 
                 try:
                     _LOGGER.debug("Sending keepalive request")
                     await self.send_request(
                         "GetParamList",
-                        request_timeout=10.0,
+                        request_timeout=KEEPALIVE_TIMEOUT,
                         condition="OBJTYP=SYSTEM",
                         objectList=[{"objnam": "INCR", "keys": ["MODE"]}],
                     )
-                except TimeoutError:
-                    _LOGGER.warning("Keepalive timeout - connection may be dead")
+                except (ICTimeoutError, TimeoutError) as err:
+                    _LOGGER.warning("Keepalive timeout - dropping dead connection")
+                    self._abort_connection(err)
                     break
-                except ICConnectionError as err:
-                    _LOGGER.warning("Keepalive failed: %s", err)
+                except (ICConnectionError, OSError, ConnectionError) as err:
+                    _LOGGER.warning("Keepalive failed: %s - dropping connection", err)
+                    self._abort_connection(err)
                     break
+                except ICResponseError as err:
+                    # The panel answered - the link is alive - but rejected
+                    # the request; keep the connection and keep probing.
+                    _LOGGER.warning("Keepalive request rejected: %s", err)
 
         except asyncio.CancelledError:
             _LOGGER.debug("Keepalive task cancelled")

--- a/src/pyintellicenter/controller.py
+++ b/src/pyintellicenter/controller.py
@@ -1260,7 +1260,13 @@ class ICConnectionHandler:
                 self._starter_task = None
                 return
 
-            except (TimeoutError, OSError, ICConnectionError, ICCommandError) as err:
+            except (
+                ICTimeoutError,
+                TimeoutError,
+                OSError,
+                ICConnectionError,
+                ICCommandError,
+            ) as err:
                 self._failure_count += 1
                 self._last_failure_time = time.monotonic()
                 self._controller._metrics.reconnect_attempts += 1
@@ -1290,8 +1296,10 @@ class ICConnectionHandler:
             self._delayed_disconnect(controller, exc)
         )
 
-        # Start reconnection
-        self._starter_task = asyncio.create_task(self._starter(self._time_between_reconnects))
+        # Start reconnection - unless one is already in flight (multiple
+        # disconnect paths can fire for the same dead connection)
+        if not self._starter_task or self._starter_task.done():
+            self._starter_task = asyncio.create_task(self._starter(self._time_between_reconnects))
 
     async def _delayed_disconnect(
         self, controller: ICBaseController, exc: Exception | None

--- a/tests/test_dead_link_detection.py
+++ b/tests/test_dead_link_detection.py
@@ -1,0 +1,465 @@
+"""Regression tests for dead-link detection (WebSocket reader loop + keepalive).
+
+These cover the failure mode where the link to IntelliCenter dies but the
+disconnect callback never fires, leaving the connection "connected" with
+frozen state until a manual restart:
+
+1. ``ICWebSocketTransport._reader_loop`` only caught ``OSError`` /
+   ``ConnectionError``, but the websockets library raises ``ConnectionClosed``
+   (a ``WebSocketException``) on abnormal closes - the reader task died
+   without running the disconnect path.
+2. A clean server-side close ends the reader's ``async for`` without any
+   exception - the disconnect path never ran either.
+3. ``ICConnection._keepalive_loop`` caught ``TimeoutError``, but
+   ``send_request`` raises ``ICTimeoutError`` (an ``ICError``, not a
+   ``TimeoutError``) - a keepalive timeout killed the keepalive task with an
+   unretrieved exception ("Task exception was never retrieved").
+4. When the keepalive loop did catch a failure it only logged and exited:
+   detection without recovery - no teardown, no disconnect callback, no
+   reconnect.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import contextlib
+from typing import Any
+
+import pytest
+import websockets
+from websockets.exceptions import ConnectionClosedError
+
+from pyintellicenter import (
+    ICBaseController,
+    ICConnection,
+    ICConnectionError,
+    ICConnectionHandler,
+    ICResponseError,
+    ICTimeoutError,
+)
+from pyintellicenter import connection as connection_module
+from pyintellicenter.connection import ICWebSocketTransport
+
+
+def make_abnormal_close() -> ConnectionClosedError:
+    """Build a 1006-style close: connection lost without a close frame."""
+    return ConnectionClosedError(None, None)
+
+
+class FakeWebSocket:
+    """Minimal stand-in for a websockets client connection.
+
+    Yields queued messages, then either ends iteration (clean server close)
+    or raises the configured exception (abnormal close). With ``block=True``
+    it stalls forever after the queued messages, until cancelled.
+    """
+
+    def __init__(
+        self,
+        messages: list[str] | None = None,
+        end_with: Exception | None = None,
+        block: bool = False,
+    ) -> None:
+        self._messages = list(messages or [])
+        self._end_with = end_with
+        self._block = block
+        self.sent: list[str] = []
+        self.send_error: Exception | None = None
+
+    def __aiter__(self) -> FakeWebSocket:
+        return self
+
+    async def __anext__(self) -> str:
+        if self._messages:
+            return self._messages.pop(0)
+        if self._block:
+            await asyncio.Event().wait()
+        if self._end_with is not None:
+            raise self._end_with
+        raise StopAsyncIteration
+
+    async def send(self, data: str) -> None:
+        if self.send_error is not None:
+            raise self.send_error
+        self.sent.append(data)
+
+    async def close(self) -> None:
+        return
+
+
+class FakeDeadLinkProtocol:
+    """Transport stand-in for a half-open link.
+
+    ``connected`` stays True (the transport has not noticed anything) but
+    every request fails with the configured error - exactly the state the
+    keepalive loop exists to detect.
+    """
+
+    def __init__(self, error: Exception) -> None:
+        self._error = error
+        self.connected = True
+        self.close_calls = 0
+        self._disconnect_callback: Any = None
+
+    async def send_request(
+        self, command: str, request_timeout: float = 30.0, **kwargs: Any
+    ) -> dict[str, Any]:
+        raise self._error
+
+    def close(self) -> None:
+        self.close_calls += 1
+        self.connected = False
+
+
+class TestWebSocketReaderDeadLink:
+    """The reader loop must run the disconnect path on every link death."""
+
+    @pytest.mark.asyncio
+    async def test_abnormal_close_fires_disconnect_callback(self):
+        """ConnectionClosed from the websockets iterator must not kill the reader silently."""
+        disconnects: list[Exception | None] = []
+        transport = ICWebSocketTransport(disconnect_callback=disconnects.append)
+        exc = make_abnormal_close()
+        transport._ws = FakeWebSocket(messages=['{"command": "NotifyList"}'], end_with=exc)
+        transport._connected = True
+
+        await transport._reader_loop()
+
+        assert disconnects == [exc]
+        assert transport.connected is False
+
+    @pytest.mark.asyncio
+    async def test_abnormal_close_fails_pending_request_fast(self):
+        """A request in flight when the link dies must fail, not hang."""
+        transport = ICWebSocketTransport()
+        transport._ws = FakeWebSocket(end_with=make_abnormal_close())
+        transport._connected = True
+        future: asyncio.Future[dict[str, Any]] = asyncio.get_running_loop().create_future()
+        transport._response_future = future
+        transport._pending_message_id = "1"
+
+        await transport._reader_loop()
+
+        assert future.done()
+        with pytest.raises(ICConnectionError):
+            future.result()
+
+    @pytest.mark.asyncio
+    async def test_clean_server_close_fires_disconnect_callback(self):
+        """A clean close ends iteration without an exception - still a disconnect."""
+        disconnects: list[Exception | None] = []
+        transport = ICWebSocketTransport(disconnect_callback=disconnects.append)
+        transport._ws = FakeWebSocket(messages=['{"command": "NotifyList"}'])
+        transport._connected = True
+
+        await transport._reader_loop()
+
+        assert disconnects == [None]
+        assert transport.connected is False
+
+    @pytest.mark.asyncio
+    async def test_cancelled_reader_does_not_fire_disconnect(self):
+        """Deliberate close() cancels the reader; that is not a link failure."""
+        disconnects: list[Exception | None] = []
+        transport = ICWebSocketTransport(disconnect_callback=disconnects.append)
+        transport._ws = FakeWebSocket(block=True)
+        transport._connected = True
+
+        task = asyncio.create_task(transport._reader_loop())
+        await asyncio.sleep(0.01)
+        task.cancel()
+        with contextlib.suppress(asyncio.CancelledError):
+            await task
+
+        assert disconnects == []
+
+    @pytest.mark.asyncio
+    async def test_handle_disconnect_fires_callback_exactly_once(self):
+        """Racing disconnect paths must collapse into a single callback."""
+        disconnects: list[Exception | None] = []
+        transport = ICWebSocketTransport(disconnect_callback=disconnects.append)
+        transport._connected = True
+
+        transport._handle_disconnect(None)
+        transport._handle_disconnect(make_abnormal_close())
+
+        assert disconnects == [None]
+
+
+class TestWebSocketSendDeadLink:
+    """Send failures on a dead socket must surface as library errors."""
+
+    @pytest.mark.asyncio
+    async def test_send_on_closed_socket_raises_ic_connection_error(self):
+        """ConnectionClosed from ws.send() must become ICConnectionError."""
+        transport = ICWebSocketTransport()
+        ws = FakeWebSocket(block=True)
+        ws.send_error = make_abnormal_close()
+        transport._ws = ws
+        transport._connected = True
+
+        with pytest.raises(ICConnectionError):
+            await transport.send_request("GetParamList", request_timeout=1.0)
+
+
+class TestKeepaliveDeadLink:
+    """A failed keepalive must tear the connection down, not die quietly."""
+
+    @staticmethod
+    def _connection_with(
+        protocol: FakeDeadLinkProtocol, keepalive_interval: float = 0.01
+    ) -> tuple[ICConnection, list[Exception | None]]:
+        disconnects: list[Exception | None] = []
+        conn = ICConnection("192.168.1.100", keepalive_interval=keepalive_interval)
+        conn.set_disconnect_callback(disconnects.append)
+        conn._protocol = protocol  # type: ignore[assignment]
+        return conn, disconnects
+
+    @pytest.mark.asyncio
+    async def test_keepalive_timeout_fires_disconnect_and_tears_down(self):
+        """ICTimeoutError (not TimeoutError!) must be handled and trigger teardown."""
+        protocol = FakeDeadLinkProtocol(ICTimeoutError("Request GetParamList timed out"))
+        conn, disconnects = self._connection_with(protocol)
+
+        task = asyncio.create_task(conn._keepalive_loop())
+        conn._keepalive_task = task
+        await asyncio.wait_for(task, timeout=2.0)
+
+        assert len(disconnects) == 1
+        assert isinstance(disconnects[0], ICTimeoutError)
+        assert protocol.close_calls == 1
+        assert conn.connected is False
+        assert task.exception() is None  # no "Task exception was never retrieved"
+
+    @pytest.mark.asyncio
+    async def test_keepalive_connection_error_fires_disconnect(self):
+        """Detection without recovery: a caught failure must still tear down."""
+        protocol = FakeDeadLinkProtocol(ICConnectionError("Connection lost"))
+        conn, disconnects = self._connection_with(protocol)
+
+        task = asyncio.create_task(conn._keepalive_loop())
+        conn._keepalive_task = task
+        await asyncio.wait_for(task, timeout=2.0)
+
+        assert len(disconnects) == 1
+        assert isinstance(disconnects[0], ICConnectionError)
+        assert conn.connected is False
+
+    @pytest.mark.asyncio
+    async def test_keepalive_response_error_keeps_probing(self):
+        """An error response proves the link is alive: keep the connection.
+
+        Previously ICResponseError was uncaught and killed the keepalive task.
+        """
+        protocol = FakeDeadLinkProtocol(ICResponseError("400"))
+        conn, disconnects = self._connection_with(protocol)
+
+        task = asyncio.create_task(conn._keepalive_loop())
+        conn._keepalive_task = task
+        await asyncio.sleep(0.05)  # several keepalive rounds
+
+        try:
+            assert disconnects == []
+            assert conn.connected is True
+            assert not task.done()  # the keepalive task survived and keeps probing
+        finally:
+            task.cancel()
+            with contextlib.suppress(asyncio.CancelledError):
+                await task
+
+    @pytest.mark.asyncio
+    async def test_connection_dispatches_disconnect_at_most_once(self):
+        """Racing disconnect paths at the ICConnection level collapse to one callback."""
+        protocol = FakeDeadLinkProtocol(ICConnectionError("unused"))
+        conn, disconnects = self._connection_with(protocol)
+
+        conn._on_disconnect(None)
+        conn._on_disconnect(ICConnectionError("late transport notification"))
+
+        assert disconnects == [None]
+
+    @pytest.mark.asyncio
+    async def test_keepalive_exits_quietly_after_transport_disconnect(self):
+        """If the transport already handled the disconnect, do not double-fire."""
+        protocol = FakeDeadLinkProtocol(ICConnectionError("unused"))
+        protocol.connected = False  # transport disconnect path already ran
+        conn, disconnects = self._connection_with(protocol)
+
+        task = asyncio.create_task(conn._keepalive_loop())
+        conn._keepalive_task = task
+        await asyncio.wait_for(task, timeout=2.0)
+
+        assert disconnects == []
+
+    @pytest.mark.asyncio
+    async def test_cancelled_keepalive_does_not_fire_disconnect(self):
+        """Deliberate disconnect() cancels the keepalive; no callback expected."""
+        protocol = FakeDeadLinkProtocol(ICConnectionError("unused"))
+        conn, disconnects = self._connection_with(protocol, keepalive_interval=60.0)
+
+        task = asyncio.create_task(conn._keepalive_loop())
+        conn._keepalive_task = task
+        await asyncio.sleep(0.01)
+        task.cancel()
+        with contextlib.suppress(asyncio.CancelledError):
+            await task
+
+        assert disconnects == []
+
+
+class TestHandlerSingleStarter:
+    """ICConnectionHandler must never stack a second reconnect loop."""
+
+    @pytest.mark.asyncio
+    async def test_concurrent_disconnects_spawn_one_starter(self):
+        controller = ICBaseController("192.168.1.100")
+        handler = ICConnectionHandler(
+            controller, time_between_reconnects=1, disconnect_debounce_time=1
+        )
+
+        async def fake_starter(initial_delay: int = 0) -> None:
+            await asyncio.Event().wait()  # a reconnect loop that never finishes
+
+        handler._starter = fake_starter  # type: ignore[method-assign]
+
+        handler._on_disconnect(controller, None)
+        first = handler._starter_task
+        handler._on_disconnect(controller, ConnectionResetError("second disconnect path"))
+
+        try:
+            assert first is not None
+            assert handler._starter_task is first
+        finally:
+            for task in (handler._starter_task, handler._disconnect_debounce_task):
+                if task:
+                    task.cancel()
+                    with contextlib.suppress(asyncio.CancelledError):
+                        await task
+
+
+class TestHandlerStarterResilience:
+    """The reconnect loop itself must survive request-level timeouts."""
+
+    @pytest.mark.asyncio
+    async def test_starter_retries_after_ic_timeout_error(self):
+        """ICTimeoutError from controller.start() must not kill reconnection.
+
+        send_request raises ICTimeoutError (an ICError, not a TimeoutError),
+        so the retry loop's `except TimeoutError` never matched and a request
+        timeout during a reconnect attempt ended reconnection permanently.
+        """
+        controller = ICBaseController("192.168.1.100")
+        attempts = 0
+
+        async def failing_start() -> None:
+            nonlocal attempts
+            attempts += 1
+            raise ICTimeoutError("Request GetParamList timed out")
+
+        controller.start = failing_start  # type: ignore[method-assign]
+        handler = ICConnectionHandler(
+            controller, time_between_reconnects=0, disconnect_debounce_time=1
+        )
+
+        task = asyncio.create_task(handler._starter(initial_delay=0))
+        await asyncio.sleep(0.05)
+
+        try:
+            assert not task.done()  # previously: task died on the first ICTimeoutError
+            assert attempts >= 2  # and it kept retrying
+        finally:
+            task.cancel()
+            with contextlib.suppress(asyncio.CancelledError):
+                await task
+
+
+class TestWebSocketEndToEnd:
+    """End-to-end checks against a real websockets server."""
+
+    @staticmethod
+    async def _run_server_close_scenario(code: int) -> tuple[list[Exception | None], ICConnection]:
+        """Connect, have the server close with the given code, await the callback."""
+        close_now = asyncio.Event()
+
+        async def handler(ws: Any) -> None:
+            await close_now.wait()
+            await ws.close(code=code)
+
+        disconnected = asyncio.Event()
+        disconnects: list[Exception | None] = []
+
+        def on_disconnect(exc: Exception | None) -> None:
+            disconnects.append(exc)
+            disconnected.set()
+
+        server = await websockets.serve(handler, "127.0.0.1", 0)
+        try:
+            port = server.sockets[0].getsockname()[1]
+            conn = ICConnection("127.0.0.1", port=port, transport="websocket")
+            conn.set_disconnect_callback(on_disconnect)
+            await conn.connect()
+            try:
+                close_now.set()
+                await asyncio.wait_for(disconnected.wait(), timeout=2.0)
+            finally:
+                await conn.disconnect()
+        finally:
+            server.close()
+            await server.wait_closed()
+
+        return disconnects, conn
+
+    @pytest.mark.asyncio
+    async def test_server_clean_close_triggers_disconnect(self):
+        """Close code 1000: iteration ends normally - callback must still fire."""
+        disconnects, conn = await self._run_server_close_scenario(code=1000)
+
+        assert disconnects == [None]
+        assert conn.connected is False
+
+    @pytest.mark.asyncio
+    async def test_server_abnormal_close_triggers_disconnect(self):
+        """Close code 4000: websockets raises ConnectionClosedError - callback must fire."""
+        disconnects, conn = await self._run_server_close_scenario(code=4000)
+
+        assert len(disconnects) == 1
+        assert isinstance(disconnects[0], ConnectionClosedError)
+        assert conn.connected is False
+
+    @pytest.mark.asyncio
+    async def test_unresponsive_server_keepalive_aborts_connection(self, monkeypatch):
+        """Server accepts but never answers: the keepalive must detect and abort."""
+
+        async def handler(ws: Any) -> None:
+            with contextlib.suppress(Exception):
+                async for _message in ws:
+                    pass  # swallow requests, never answer
+
+        monkeypatch.setattr(connection_module, "KEEPALIVE_TIMEOUT", 0.2, raising=False)
+
+        disconnected = asyncio.Event()
+        disconnects: list[Exception | None] = []
+
+        def on_disconnect(exc: Exception | None) -> None:
+            disconnects.append(exc)
+            disconnected.set()
+
+        server = await websockets.serve(handler, "127.0.0.1", 0)
+        try:
+            port = server.sockets[0].getsockname()[1]
+            conn = ICConnection(
+                "127.0.0.1", port=port, transport="websocket", keepalive_interval=0.05
+            )
+            conn.set_disconnect_callback(on_disconnect)
+            await conn.connect()
+            try:
+                await asyncio.wait_for(disconnected.wait(), timeout=2.0)
+            finally:
+                await conn.disconnect()
+        finally:
+            server.close()
+            await server.wait_closed()
+
+        assert len(disconnects) == 1
+        assert isinstance(disconnects[0], ICTimeoutError)
+        assert conn.connected is False


### PR DESCRIPTION
## Problem

A connection that dies without raising `OSError` is never noticed, and the library freezes in a permanently "connected" state with no reconnection. Field evidence from my install (HA integration v3.7.0, WebSocket transport, port 6680): the bridge link dropped silently at ~04:42 UTC on 2026-06-09 and **all entities stayed frozen-but-available for 22.2 hours** (the bridge answered ping the whole time; the integration's `available` is `bool(coordinator.connected)`, which never flipped) until a manual Home Assistant restart. The HA log showed `Task exception was never retrieved` — the keepalive task dying, see below.

Four distinct defects compound into this:

1. **WS reader misses `ConnectionClosed` and clean closes** (`connection.py`, `_reader_loop`). The loop catches only `(OSError, ConnectionError)`, but the websockets library raises `ConnectionClosed` — a `WebSocketException`, not an `OSError` — on abnormal close: uncaught, the reader task dies without calling `_handle_disconnect()`. A *clean* peer close ends the `async for` without any exception and fell out of the try block — also never calling `_handle_disconnect()`. Either way: no disconnect callback, no reconnect.
2. **Keepalive catches the wrong timeout type and never tears down** (`connection.py`, `_keepalive_loop`). `send_request()` raises `ICTimeoutError` on timeout, which subclasses `ICError` — **not** `TimeoutError` — so `except TimeoutError` never matches and the keepalive task dies with an unretrieved exception. And even the branches that did match only logged a warning and `break`-ed: nothing closed the transport or fired the disconnect callback, so a half-open link (e.g. bridge power-cycle) stayed "connected" forever.
3. **`ICConnectionHandler._starter` dies on `ICTimeoutError`** — the same class confusion in the reconnect retry loop: a request-level timeout during a reconnect attempt kills reconnection permanently.
4. **Duplicate reconnect loops** — `_on_disconnect` unconditionally overwrites `_starter_task`, so racing disconnect notifications could spawn parallel `_starter` loops.

## Fix

- `_reader_loop`: catch `(WebSocketException, OSError, ConnectionError)` — the full `WebSocketException` hierarchy rather than just `ConnectionClosed`, so no websockets-level error can kill the reader silently — and run `_handle_disconnect(exc)` on **every** non-cancellation exit, including the exception-free clean close. Local `close()`/`aclose()` cancellation still exits silently.
- `_handle_disconnect`: idempotent — only the first call dispatches.
- `_keepalive_loop`: catch `(ICTimeoutError, TimeoutError)` and `(ICConnectionError, OSError, ConnectionError)`; on failure call the new `ICConnection._abort_connection()` — close the transport and dispatch the disconnect callback, at most once per connection even if the transport's own teardown races it (the transport's disconnect callback is detached first, so e.g. a late TCP `connection_lost` after `close()` cannot re-fire it). `ICResponseError` keeps probing instead — the panel answered, so the link is alive. The callback receives the original exception (e.g. `ICTimeoutError`) for diagnosability.
- WS `send_request()`: translate `(WebSocketException, OSError, ConnectionError)` from `ws.send()` into `ICConnectionError` (callers see the documented exception types).
- `ICConnectionHandler`: `_starter` also catches `ICTimeoutError`; `_on_disconnect` only spawns a starter when none is running.
- The keepalive's hardcoded 10.0s response timeout is now the `KEEPALIVE_TIMEOUT` module constant.
- TCP transport audited for the same gaps: its reader side is safe (asyncio guarantees `connection_lost`), and it shares the fixed keepalive loop.

## Tests

17 new red-first regression tests in `tests/test_dead_link_detection.py` — every listed defect fails on `main` and passes here:

- Unit level: fake WS that closes cleanly / raises `ConnectionClosed` / hangs; fake half-open transport driving the keepalive (timeout, connection error, error response, deliberate cancel); exactly-once dispatch at both the transport and `ICConnection` levels; handler duplicate-starter and retry-on-`ICTimeoutError` cases.
- End-to-end against a **real websockets server**: clean close (1000) and abnormal close (4000) both fire the disconnect callback exactly once, and an accept-but-never-answer server is detected by the keepalive, which aborts the connection.

Validation (matching CI): `pytest` **418 passed** (401 baseline + 17 new); `ruff check` / `ruff format --check` clean; `mypy src` clean (Python 3.13, websockets 16).

Related: this is the runtime-outage counterpart to the startup-retry fix that shipped in the HA integration v3.7.0 (intellicenter PR #44). With this in place, the integration's `available = coordinator.connected` actually flips on a dead link and `ICConnectionHandler` reconnects — no more frozen entities.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
