### PR TITLE
fix: reconnect/keepalive resilience — ICTimeoutError handling, starter race, connection leaks

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.1.20] - 2026-06-10
+
 ### Fixed
 
 - **Dead-link detection: silent connection freezes now trigger the disconnect
@@ -43,6 +45,21 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
     connection.
   - The TCP transport needed no reader-side change (asyncio guarantees
     `connection_lost`); it shares the fixed keepalive loop.
+
+- **Connection lifecycle hardening** (companion fixes to the dead-link work
+  above):
+  - `ICBaseController.start()` now disconnects the connection it replaces
+    (previously the old socket and its keepalive task leaked), and disconnect
+    callbacks are identity-checked so a replaced connection's late death
+    cannot masquerade as - or tear down - the live connection.
+  - `ICConnectionHandler._starter` re-checks `_stopped` after its backoff
+    sleeps so a reconnect racing `stop()` cannot open a connection nothing
+    will ever close, and a starter only clears its *own* task reference.
+  - The keepalive now declares the link dead after `KEEPALIVE_MAX_FAILURES`
+    (3) *consecutive* missed responses - the documented design - instead of
+    the first miss; a success (or an error response, which proves the link is
+    alive) resets the count, while a connection error still tears down
+    immediately.
 
 ## [0.1.19] - 2026-06-01
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "pyintellicenter"
-version = "0.1.19"
+version = "0.1.20"
 description = "Python library for Pentair IntelliCenter pool control systems"
 readme = "README.md"
 license = "MIT"

--- a/src/pyintellicenter/__init__.py
+++ b/src/pyintellicenter/__init__.py
@@ -185,7 +185,7 @@ try:
 except ImportError:
     _DISCOVERY_AVAILABLE = False
 
-__version__ = "0.1.19"
+__version__ = "0.1.20"
 
 __all__ = [
     # Version

--- a/src/pyintellicenter/connection.py
+++ b/src/pyintellicenter/connection.py
@@ -46,6 +46,7 @@ DEFAULT_WEBSOCKET_PORT = 6680
 RESPONSE_TIMEOUT = 30.0  # seconds to wait for a response
 KEEPALIVE_INTERVAL = 90.0  # seconds between keepalive requests
 KEEPALIVE_TIMEOUT = 10.0  # seconds to wait for a keepalive response
+KEEPALIVE_MAX_FAILURES = 3  # consecutive missed keepalives before the link is dead
 CONNECTION_TIMEOUT = 10.0  # seconds to wait for initial connection
 MAX_BUFFER_SIZE = 1024 * 1024  # 1MB max buffer to prevent DoS
 DEFAULT_NOTIFICATION_QUEUE_SIZE = 100  # max queued notifications
@@ -879,7 +880,14 @@ class ICConnection:
 
         Note: send_request raises ICTimeoutError (an ICError, not a
         TimeoutError) on timeout, so both are handled explicitly here.
+
+        A single missed response does not prove death (the panel can be busy
+        servicing another client); the link is declared dead after
+        ``KEEPALIVE_MAX_FAILURES`` consecutive timeouts - the documented
+        design. A connection error, by contrast, is definitive and tears the
+        connection down immediately.
         """
+        failures = 0
         try:
             while self.connected:
                 await asyncio.sleep(self._keepalive_interval)
@@ -895,10 +903,21 @@ class ICConnection:
                         condition="OBJTYP=SYSTEM",
                         objectList=[{"objnam": "INCR", "keys": ["MODE"]}],
                     )
+                    failures = 0
                 except (ICTimeoutError, TimeoutError) as err:
-                    _LOGGER.warning("Keepalive timeout - dropping dead connection")
-                    self._abort_connection(err)
-                    break
+                    failures += 1
+                    _LOGGER.warning(
+                        "Keepalive timeout (%d/%d) - connection may be dead",
+                        failures,
+                        KEEPALIVE_MAX_FAILURES,
+                    )
+                    if failures >= KEEPALIVE_MAX_FAILURES:
+                        _LOGGER.warning(
+                            "Dropping dead connection after %d consecutive keepalive timeouts",
+                            failures,
+                        )
+                        self._abort_connection(err)
+                        break
                 except (ICConnectionError, OSError, ConnectionError) as err:
                     _LOGGER.warning("Keepalive failed: %s - dropping connection", err)
                     self._abort_connection(err)
@@ -906,6 +925,7 @@ class ICConnection:
                 except ICResponseError as err:
                     # The panel answered - the link is alive - but rejected
                     # the request; keep the connection and keep probing.
+                    failures = 0
                     _LOGGER.warning("Keepalive request rejected: %s", err)
 
         except asyncio.CancelledError:

--- a/src/pyintellicenter/controller.py
+++ b/src/pyintellicenter/controller.py
@@ -482,16 +482,33 @@ class ICBaseController:
             ICConnectionError: If connection fails
             ICCommandError: If system info request fails
         """
+        # Tear down any previous connection before replacing it: overwriting
+        # the reference leaks the old socket and its keepalive task, and a late
+        # disconnect event from it would masquerade as the live connection's.
+        if self._connection:
+            with contextlib.suppress(Exception):
+                await self._connection.disconnect()
+            self._connection = None
+
         # Create connection
-        self._connection = ICConnection(
+        connection = ICConnection(
             self._host,
             self._port,
             keepalive_interval=self._keepalive_interval,
             transport=self._transport,
         )
 
-        # Set disconnect callback
-        self._connection.set_disconnect_callback(self._on_disconnect)
+        # Set disconnect callback. The identity check ignores events from a
+        # connection this controller has since replaced - a stale socket dying
+        # must not tear down (or trigger reconnection of) the live one.
+        def _on_connection_disconnect(exc: Exception | None) -> None:
+            if self._connection is connection:
+                self._on_disconnect(exc)
+            else:
+                _LOGGER.debug("Ignoring disconnect from a replaced connection")
+
+        connection.set_disconnect_callback(_on_connection_disconnect)
+        self._connection = connection
 
         # Connect
         await self._connection.connect()
@@ -1176,7 +1193,8 @@ class ICConnectionHandler:
                         self.on_started(self._controller)
                         self._first_time = False
                     self._is_connected = True
-                    self._starter_task = None
+                    if self._starter_task is asyncio.current_task():
+                        self._starter_task = None
                 except (ICTimeoutError, OSError, ICConnectionError, ICCommandError) as err:
                     first_attempt_error = err
                 finally:
@@ -1240,6 +1258,12 @@ class ICConnectionHandler:
                     await asyncio.sleep(initial_delay)
                     initial_delay = 0
 
+                # Re-check after the sleeps above: stop() may have run while we
+                # waited, and opening a fresh connection past that point would
+                # leave a socket nothing ever closes.
+                if self._stopped:
+                    return
+
                 await self._controller.start()
 
                 # Success - reset circuit breaker
@@ -1257,7 +1281,10 @@ class ICConnectionHandler:
                     self.on_reconnected(self._controller)
 
                 self._is_connected = True
-                self._starter_task = None
+                # Only clear the reference if it points at THIS task; clearing
+                # someone else's reference would let stop() miss it.
+                if self._starter_task is asyncio.current_task():
+                    self._starter_task = None
                 return
 
             except (

--- a/tests/test_reconnect_hardening.py
+++ b/tests/test_reconnect_hardening.py
@@ -1,0 +1,176 @@
+"""Regression tests for reconnect/connection-lifecycle hardening.
+
+Complements tests/test_dead_link_detection.py (PR #41): these cover the
+handler/controller lifecycle gaps fixed alongside it - stop() racing a
+delayed reconnect, connection replacement leaks, stale-connection disconnect
+events, and the documented 3-consecutive-miss keepalive policy.
+"""
+
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+
+from pyintellicenter import (
+    ICBaseController,
+    ICConnection,
+    ICConnectionError,
+    ICConnectionHandler,
+    ICConnectionMetrics,
+    ICTimeoutError,
+)
+from pyintellicenter.connection import KEEPALIVE_MAX_FAILURES
+
+
+class TestStarterStopRecheck:
+    """A starter waking from its delay must honour stop()."""
+
+    @pytest.mark.asyncio
+    async def test_starter_aborts_when_stopped_during_delay(self):
+        """After stop(), a starter waking from its delay must not reconnect."""
+        controller = MagicMock()
+        controller.start = AsyncMock()
+        controller.stop = AsyncMock()
+        controller.host = "192.168.1.100"
+        controller._metrics = ICConnectionMetrics()
+        controller.set_disconnected_callback = MagicMock()
+
+        handler = ICConnectionHandler(controller, time_between_reconnects=1)
+        # Simulate the stop flag flipping while the starter slept; the loop
+        # must bail out before opening a connection nothing would ever close.
+        handler._stopped = True
+        await handler._starter(initial_delay=0)
+        controller.start.assert_not_called()
+
+
+class TestConnectionReplacement:
+    """ICBaseController.start() must not leak or confuse replaced connections."""
+
+    def _mock_connection(self):
+        mock_connection = AsyncMock()
+        mock_connection.connected = True
+        mock_connection.connect = AsyncMock()
+        mock_connection.set_disconnect_callback = MagicMock()
+        mock_connection.send_request = AsyncMock(
+            return_value={
+                "response": "200",
+                "objectList": [
+                    {
+                        "objnam": "INCR",
+                        "params": {
+                            "PROPNAME": "Test Pool",
+                            "VER": "1.0.0",
+                            "MODE": "ENGLISH",
+                            "SNAME": "TestSystem",
+                        },
+                    }
+                ],
+            }
+        )
+        return mock_connection
+
+    @pytest.mark.asyncio
+    async def test_start_disconnects_previous_connection(self):
+        """start() must tear down the connection it replaces, not leak it."""
+        controller = ICBaseController("192.168.1.100", 6681)
+        old_connection = AsyncMock()
+        controller._connection = old_connection
+
+        new_connection = self._mock_connection()
+        with patch(
+            "pyintellicenter.controller.ICConnection",
+            return_value=new_connection,
+        ):
+            await controller.start()
+
+        old_connection.disconnect.assert_awaited_once()
+        assert controller._connection is new_connection
+
+    @pytest.mark.asyncio
+    async def test_stale_connection_disconnect_is_ignored(self):
+        """A replaced connection's late disconnect must not affect the live one."""
+        controller = ICBaseController("192.168.1.100", 6681)
+        events: list[str] = []
+        controller.set_disconnected_callback(lambda ctrl, exc: events.append(str(exc)))
+
+        first = self._mock_connection()
+        second = self._mock_connection()
+        with patch(
+            "pyintellicenter.controller.ICConnection",
+            side_effect=[first, second],
+        ):
+            await controller.start()
+            stale_callback = first.set_disconnect_callback.call_args[0][0]
+            await controller.start()  # replaces `first` with `second`
+
+        # The stale socket dies late: the controller must ignore it.
+        stale_callback(Exception("stale socket died"))
+        assert events == []
+
+        # The live connection's events still propagate.
+        live_callback = second.set_disconnect_callback.call_args[0][0]
+        live_callback(Exception("live drop"))
+        assert events == ["live drop"]
+
+
+class TestKeepaliveMissPolicy:
+    """The link is dead after KEEPALIVE_MAX_FAILURES consecutive misses.
+
+    A single missed response does not prove death (the panel can be busy
+    servicing another client); teardown must wait for the documented number
+    of consecutive misses, and a success in between resets the count.
+    """
+
+    def _connection_with_mock_protocol(self) -> ICConnection:
+        conn = ICConnection("192.168.1.100", 6681)
+        protocol = MagicMock()
+        protocol.connected = True
+        conn._protocol = protocol
+        return conn
+
+    @pytest.mark.asyncio
+    async def test_teardown_after_max_consecutive_misses(self):
+        conn = self._connection_with_mock_protocol()
+        protocol = conn._protocol  # _abort_connection detaches it after closing
+        conn.send_request = AsyncMock(side_effect=ICTimeoutError("Request GetParamList timed out"))
+
+        with patch("asyncio.sleep", new=AsyncMock()):
+            await conn._keepalive_loop()
+
+        assert conn.send_request.await_count == KEEPALIVE_MAX_FAILURES
+        protocol.close.assert_called_once()
+
+    @pytest.mark.asyncio
+    async def test_success_resets_the_miss_count(self):
+        conn = self._connection_with_mock_protocol()
+        protocol = conn._protocol  # _abort_connection detaches it after closing
+        conn.send_request = AsyncMock(
+            side_effect=[
+                ICTimeoutError("timeout 1"),
+                ICTimeoutError("timeout 2"),
+                {"response": "200"},  # recovery resets the count
+                ICTimeoutError("timeout 3"),
+                ICTimeoutError("timeout 4"),
+                ICTimeoutError("timeout 5"),
+            ]
+        )
+
+        with patch("asyncio.sleep", new=AsyncMock()):
+            await conn._keepalive_loop()
+
+        # All six calls were made: the two early misses did not accumulate
+        # with the three post-recovery misses into an early teardown.
+        assert conn.send_request.await_count == 6
+        protocol.close.assert_called_once()
+
+    @pytest.mark.asyncio
+    async def test_connection_error_still_immediate(self):
+        """A connection error is definitive - no miss-counting applies."""
+        conn = self._connection_with_mock_protocol()
+        protocol = conn._protocol  # _abort_connection detaches it after closing
+        conn.send_request = AsyncMock(side_effect=ICConnectionError("Not connected"))
+
+        with patch("asyncio.sleep", new=AsyncMock()):
+            await conn._keepalive_loop()
+
+        assert conn.send_request.await_count == 1
+        protocol.close.assert_called_once()

--- a/uv.lock
+++ b/uv.lock
@@ -201,7 +201,7 @@ wheels = [
 
 [[package]]
 name = "pyintellicenter"
-version = "0.1.19"
+version = "0.1.20"
 source = { editable = "." }
 dependencies = [
     { name = "orjson" },


### PR DESCRIPTION
## Summary

**Rebased on top of #41** (merritt925's dead-link detection — thanks for the excellent field-validated work). This PR now carries only the complementary lifecycle fixes:

1. **`ICBaseController.start()` leaked the connection it replaced** — the previous connection is now disconnected before a new one is created, and disconnect callbacks are identity-checked so a stale socket's late death can't masquerade as (or tear down) the live connection.
2. **`_starter` could open a connection after `stop()`** — `_stopped` is re-checked after the backoff sleeps, and a starter only clears its *own* `_starter_task` reference.
3. **Keepalive 3-consecutive-miss policy** — per the documented design, one missed response (panel busy serving another client) no longer tears the link down; `KEEPALIVE_MAX_FAILURES = 3` consecutive misses do. A success or an error response (link demonstrably alive) resets the count; connection errors still tear down immediately. Built on #41's `_abort_connection` machinery.

Releases as **v0.1.20** together with #41.

## Test plan
- 6 new regression tests in `tests/test_reconnect_hardening.py` (424 total, all passing)
- `ruff check`, `ruff format`, `mypy` clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)