### PR TITLE
docs: add JoyfulHouse Discord community link

### DIFF
--- a/README.md
+++ b/README.md
@@ -246,6 +246,7 @@ uv run mypy src/pyintellicenter
 
 ## Support
 
+- Join the [JoyfulHouse Discord](https://discord.gg/gc4eTPwxjJ) for support and discussion across all JoyfulHouse Home Assistant integrations and libraries.
 - **Issues:** <https://github.com/joyfulhouse/pyintellicenter/issues>
 - **PyPI:** <https://pypi.org/project/pyintellicenter/>
 


### PR DESCRIPTION
Adds the JoyfulHouse community Discord invite to the README.