### PR TITLE
feat: model real light groups and add Color Sync

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,33 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- Add dedicated TCP and WebSocket Color Sync for evidence-supported light-group
+  parents. Completion requires sender-side `SYNC` onset and terminal edges on
+  the sending connection, a full post-terminal observation interval, and an
+  authoritative final read. `ICLightGroupError` exposes phase-aware delivery and
+  completion certainty.
+
+### Changed
+
+- Restrict the state-changing Color Sync envelope to the exact raw firmware token
+  `1.064`, exactly two distinct resolved `GLOW` children, and a uniform all-off
+  or all-on prestate. The action never retries or sends a recovery command;
+  later case-insensitive `SetParamList` writers through the same controller fail
+  immediately while the lifecycle owns mutation isolation. Every projected
+  circuit, membership-row, group-flag, and system invariant is monitored through
+  a mandatory 60-second post-terminal interval and final same-connection read.
+- Color Set, Color Swim, and light-group member-position writes remain
+  intentionally unimplemented because captures did not establish safe contracts.
+
+### Fixed
+
+- Model real light groups as their controllable parent `CIRCUIT` objects and
+  `CIRCGRP` objects as ordered membership rows. `get_circuit_groups()` now
+  returns group parents; `get_circuit_group_members()` exposes rows, and direct
+  standalone-row resolution remains only as a legacy compatibility path.
+
 ## [0.1.21] - 2026-07-12
 
 ### Fixed

--- a/docs/API.md
+++ b/docs/API.md
@@ -96,10 +96,11 @@ entities = controller.get_all_entities()
 #           "circuit_groups": [...], "color_light_groups": [...], ...}
 
 # Circuit group helpers
-groups              = controller.get_circuit_groups()
-circuits_in_group   = controller.get_circuits_in_group("CG001")
-has_color           = controller.circuit_group_has_color_lights("CG001")
-color_groups        = controller.get_color_light_groups()
+# Parent CIRCUIT objects are groups; CIRCGRP objects are membership rows.
+groups = controller.get_circuit_groups()
+rows = controller.get_circuit_group_members(groups[0].objnam)
+children = controller.get_circuits_in_group(groups[0].objnam)
+color_groups = controller.get_color_light_groups()
 
 # Hardware discovery queries
 config   = await controller.get_configuration()       # Bodies and circuits
@@ -174,6 +175,12 @@ def on_update(controller, changes):
 controller.set_updated_callback(on_update)
 await controller.stop()
 ```
+
+For compatibility, a legacy standalone `CIRCGRP` object with a direct
+space-separated `CIRCUIT` list can still be passed to
+`get_circuits_in_group()`. It is not returned by `get_circuit_groups()` or
+`get_color_light_groups()`; only parent `CIRCUIT` objects are enumerated as
+groups.
 
 ## ICConnectionHandler
 

--- a/docs/API.md
+++ b/docs/API.md
@@ -47,7 +47,7 @@ conn.set_disconnect_callback(lambda exc: print(f"Disconnected: {exc}"))
 Controller that maintains equipment state in a PoolModel.
 
 ```python
-from pyintellicenter import ICModelController, PoolModel
+from pyintellicenter import ICError, ICLightGroupError, ICModelController, PoolModel
 
 model = PoolModel()
 controller = ICModelController(
@@ -101,6 +101,26 @@ groups = controller.get_circuit_groups()
 rows = controller.get_circuit_group_members(groups[0].objnam)
 children = controller.get_circuits_in_group(groups[0].objnam)
 color_groups = controller.get_color_light_groups()
+
+# Verified Color Sync for an evidence-supported light-group parent.
+try:
+    await controller.run_light_group_sync(groups[0].objnam)
+except ValueError:
+    # Cached firmware or topology is outside the supported action envelope.
+    raise
+except ICLightGroupError as err:
+    if err.acknowledged or err.onset_seen:
+        # The action was acknowledged or visibly started, but completion was
+        # not proven. Inspect the physical lights before any deliberate retry.
+        raise
+    if err.dispatch_started and not err.response_received:
+        # Dispatch began, but whether the controller received it is unknown.
+        raise
+    # The controller returned an explicit rejection or malformed response.
+    raise
+except ICError:
+    # Subscription or fresh state/preflight failed before dispatch began.
+    raise
 
 # Hardware discovery queries
 config   = await controller.get_configuration()       # Bodies and circuits
@@ -181,6 +201,30 @@ space-separated `CIRCUIT` list can still be passed to
 `get_circuits_in_group()`. It is not returned by `get_circuit_groups()` or
 `get_color_light_groups()`; only parent `CIRCUIT` objects are enumerated as
 groups.
+
+`run_light_group_sync()` is deliberately narrower than the read helpers. It is
+available only when fresh and cached state both report the exact raw firmware
+token `1.064`, the parent is `CIRCUIT/LITSHO`, membership resolves to exactly two
+distinct `CIRCUIT/GLOW` children, and the parent plus both children are uniformly
+all off or all on. Color Set, Color Swim, and member-position writes are not
+implemented.
+
+The call is blocking and commonly occupies roughly 96–97 seconds plus request
+latency on the observed firmware: a one-second subscription settle, roughly
+35–36 seconds to the physical terminal edge, a full 60-second post-terminal
+observation, and a final same-connection read. It never retries or sends an
+automatic recovery command. During that complete interval, later object-changing
+calls through the same controller fail immediately with `ICError`; read-only
+commands and model notifications continue. Physical-panel writes and writes made
+through a separate raw `ICConnection` are outside that isolation boundary and
+make Sync incomplete if they alter the monitored safety projection.
+
+`ICLightGroupError` is used only after transport dispatch begins and exposes five
+read-only certainty attributes: `phase`, `dispatch_started`, `response_received`,
+`acknowledged`, and `onset_seen`. Its phase is one of `acknowledgement`, `onset`,
+`terminal`, `observation`, or `final_projection`. Any error with
+`dispatch_started=True` requires physical inspection before a deliberate retry,
+even when the controller never returned an acknowledgement.
 
 ## ICConnectionHandler
 

--- a/docs/USAGE.md
+++ b/docs/USAGE.md
@@ -66,6 +66,57 @@ await controller.set_chlorinator_output("CHEM1", 50)
 await controller.set_vacation_mode(True)
 ```
 
+### Verified light-group Color Sync
+
+The dedicated Color Sync action is evidence-scoped rather than a generic light
+group command. The controller must report the exact raw firmware token `1.064`,
+the addressed object must be a real `CIRCUIT/LITSHO` parent with exactly two
+distinct resolved `CIRCUIT/GLOW` children, and the parent plus children must be
+uniformly all off or all on. Color Set, Color Swim, and member-position writes
+are not implemented.
+
+```python
+from pyintellicenter import ICError, ICLightGroupError
+
+groups = controller.get_circuit_groups()
+rows = controller.get_circuit_group_members(groups[0].objnam)
+children = controller.get_circuits_in_group(groups[0].objnam)
+
+try:
+    acknowledgement = await controller.run_light_group_sync(groups[0].objnam)
+except ValueError:
+    # Cached firmware or topology is outside the supported action envelope.
+    raise
+except ICLightGroupError as err:
+    if err.acknowledged or err.onset_seen:
+        # The action was acknowledged or visibly started but did not prove
+        # completion. Inspect the physical lights before any retry.
+        raise
+    if err.dispatch_started and not err.response_received:
+        # Delivery is uncertain; inspect the physical lights before any retry.
+        raise
+    # An explicit rejection or malformed response was received after dispatch.
+    raise
+except ICError:
+    # A subscription, connection, or fresh state/preflight gate failed before dispatch.
+    raise
+```
+
+The successful return value is the complete correlated transport
+acknowledgement. The call commonly occupies roughly 96–97 seconds plus request
+latency on the observed firmware: one second for subscription settling, roughly
+35–36 seconds for the physical Sync lifecycle, a mandatory 60-second
+post-terminal observation, and a final read on the same connection. There is no
+automatic retry or recovery write.
+
+While the call owns the controller mutation lifecycle, later object-changing
+calls through that controller fail immediately with `ICError`; read-only commands
+and model updates continue. A physical-panel change or write through a separate
+raw `ICConnection` is outside this boundary and causes failure if it changes the
+monitored projection. `ICLightGroupError` exposes `phase`, `dispatch_started`,
+`response_received`, `acknowledged`, and `onset_seen`. Any failure with
+`dispatch_started=True` requires physical inspection before a deliberate retry.
+
 ### Subscribing to state changes
 
 ```python
@@ -95,6 +146,7 @@ from pyintellicenter import (
     ICResponseError,    # Bad response from IntelliCenter
     ICCommandError,     # Command execution error
     ICTimeoutError,     # Request timeout
+    ICLightGroupError,  # Color Sync failed after dispatch began
 )
 
 try:

--- a/src/pyintellicenter/__init__.py
+++ b/src/pyintellicenter/__init__.py
@@ -159,6 +159,7 @@ from .exceptions import (
     ICCommandError,
     ICConnectionError,
     ICError,
+    ICLightGroupError,
     ICResponseError,
     ICTimeoutError,
 )
@@ -193,6 +194,7 @@ __all__ = [
     "__version__",
     # Exceptions
     "ICError",
+    "ICLightGroupError",
     "ICConnectionError",
     "ICResponseError",
     "ICCommandError",

--- a/src/pyintellicenter/_light_group.py
+++ b/src/pyintellicenter/_light_group.py
@@ -1,0 +1,1046 @@
+"""Evidence-bounded light-group Color Sync lifecycle."""
+
+from __future__ import annotations
+
+import asyncio
+import contextlib
+import copy
+from dataclasses import dataclass
+from typing import TYPE_CHECKING, Any, Literal
+
+from .exceptions import (
+    ICCommandError,
+    ICConnectionError,
+    ICError,
+    ICLightGroupError,
+)
+
+if TYPE_CHECKING:
+    from collections.abc import Callable, Coroutine
+
+    from ._mixins.circuit_group import _CircuitGroupMixin
+
+
+SUBSCRIPTION_SETTLE_SECONDS = 1.0
+SYNC_ACTION_DEADLINE_SECONDS = 60.0
+SYNC_POST_TERMINAL_OBSERVATION_SECONDS = 60.0
+MAX_PREBASELINE_NOTIFICATIONS = 1000
+SUPPORTED_FIRMWARE = "1.064"
+SUPPORTED_CHILD_SUBTYPE = "GLOW"
+SUPPORTED_CHILD_COUNT = 2
+ACTION_FLAGS = ("SYNC", "SET", "SWIM")
+PROJECTION_KEYS = (
+    "OBJTYP",
+    "SUBTYP",
+    "PARENT",
+    "CIRCUIT",
+    "LISTORD",
+    "STATUS",
+    "USE",
+    "SYNC",
+    "SET",
+    "SWIM",
+    "VER",
+    "SERVICE",
+)
+RELEVANT_TYPES = frozenset({"SYSTEM", "CIRCUIT", "CIRCGRP"})
+OPTIONAL_FIELDS = frozenset({("CIRCUIT", "PARENT"), ("CIRCUIT", "USE"), ("CIRCGRP", "USE")})
+
+
+@dataclass(frozen=True)
+class LightGroupTopology:
+    """Immutable cached topology used to constrain every fresh projection."""
+
+    system_objnam: str
+    target_objnam: str
+    target_rows: tuple[tuple[str, str, str, str], ...]
+    target_children: tuple[str, str]
+    circuit_objnams: tuple[str, ...]
+    circuit_subtypes: tuple[tuple[str, str], ...]
+    circuit_parents: tuple[tuple[str, str | None], ...]
+    group_parent_objnams: tuple[str, ...]
+    row_objnams: tuple[str, ...]
+    row_topology: tuple[tuple[str, str, str, str], ...]
+    inventory: tuple[tuple[str, str], ...]
+
+
+@dataclass(frozen=True)
+class _SystemProjection:
+    objnam: str
+    objtype: str
+    version: str
+    service: str
+
+
+@dataclass(frozen=True)
+class _CircuitProjection:
+    objnam: str
+    objtype: str
+    subtype: str
+    parent: str | None
+    status: str
+    use: str | None
+
+
+@dataclass(frozen=True)
+class _GroupProjection:
+    objnam: str
+    sync: str
+    set_value: str
+    swim: str
+
+
+@dataclass(frozen=True)
+class _RowProjection:
+    objnam: str
+    objtype: str
+    parent: str
+    circuit: str
+    listord: str
+    use: str | None
+
+
+@dataclass(frozen=True)
+class LightGroupProjection:
+    """Normalized immutable safety projection."""
+
+    system: _SystemProjection
+    circuits: tuple[_CircuitProjection, ...]
+    groups: tuple[_GroupProjection, ...]
+    rows: tuple[_RowProjection, ...]
+
+
+def _normalize_optional(key: str, value: Any = None, *, present: bool = True) -> str | None:
+    if not present or value is None or value == key or value == "00000":
+        return None
+    if not isinstance(value, str):
+        raise ICError(f"Malformed optional {key} value")
+    return value
+
+
+def _real_value(params: dict[str, Any], key: str) -> str:
+    value = params.get(key)
+    if not isinstance(value, str) or not value or value == key or value == "00000":
+        raise ICError(f"Missing or malformed mandatory {key}")
+    return value
+
+
+def _cached_optional(obj: Any, key: str) -> str | None:
+    return _normalize_optional(key, obj[key], present=key in obj.attribute_keys)
+
+
+def build_topology(controller: _CircuitGroupMixin, group_objnam: str) -> LightGroupTopology:
+    """Build and validate the exact cached action topology without I/O."""
+    system_info = controller._system_info
+    if system_info is None or system_info.sw_version != SUPPORTED_FIRMWARE:
+        raise ValueError("Color Sync requires exact cached firmware 1.064")
+
+    model = controller._model
+    target = model[group_objnam]
+    if target is None or target.objtype != "CIRCUIT" or target.subtype != "LITSHO":
+        raise ValueError("Color Sync target is not a CIRCUIT/LITSHO parent")
+
+    rows = controller.get_circuit_group_members(group_objnam)
+    if len(rows) != SUPPORTED_CHILD_COUNT:
+        raise ValueError("Color Sync requires exactly two membership rows")
+
+    target_rows: list[tuple[str, str, str, str]] = []
+    children: list[str] = []
+    for row in rows:
+        parent = row["PARENT"]
+        child_ref = row["CIRCUIT"]
+        order = row["LISTORD"]
+        if (
+            row.objtype != "CIRCGRP"
+            or parent != group_objnam
+            or not isinstance(child_ref, str)
+            or not child_ref
+            or any(character.isspace() for character in child_ref)
+            or not isinstance(order, (str, int))
+            or order in {"LISTORD", "00000"}
+        ):
+            raise ValueError("Color Sync membership topology is malformed")
+        try:
+            if int(order) < 0:
+                raise ValueError
+        except (TypeError, ValueError) as err:
+            raise ValueError("Color Sync membership order is malformed") from err
+        child = model[child_ref]
+        if child is None or child.objtype != "CIRCUIT" or child.subtype != SUPPORTED_CHILD_SUBTYPE:
+            raise ValueError("Color Sync children must be exact CIRCUIT/GLOW objects")
+        children.append(child_ref)
+        target_rows.append((row.objnam, parent, child_ref, str(order)))
+
+    if len(set(children)) != SUPPORTED_CHILD_COUNT:
+        raise ValueError("Color Sync children must be distinct")
+
+    systems = model.get_by_type("SYSTEM")
+    if len(systems) != 1 or systems[0].objnam != system_info.objnam:
+        raise ValueError("Color Sync cached system topology must contain exactly one system")
+
+    circuits = sorted(
+        (obj for obj in model if obj.objtype == "CIRCUIT"), key=lambda obj: obj.objnam
+    )
+    group_parents = tuple(obj.objnam for obj in circuits if obj.subtype in {"CIRCGRP", "LITSHO"})
+    all_rows = sorted(model.get_by_type("CIRCGRP"), key=lambda obj: obj.objnam)
+    row_topology: list[tuple[str, str, str, str]] = []
+    for row in all_rows:
+        parent = row["PARENT"]
+        circuit = row["CIRCUIT"]
+        order = row["LISTORD"]
+        if not all(isinstance(value, str) and value for value in (parent, circuit)):
+            raise ValueError("Color Sync cached membership topology is incomplete")
+        if not isinstance(order, (str, int)):
+            raise ValueError("Color Sync cached membership order is incomplete")
+        row_topology.append((row.objnam, parent, circuit, str(order)))
+
+    return LightGroupTopology(
+        system_objnam=system_info.objnam,
+        target_objnam=group_objnam,
+        target_rows=tuple(target_rows),
+        target_children=(children[0], children[1]),
+        circuit_objnams=tuple(obj.objnam for obj in circuits),
+        circuit_subtypes=tuple((obj.objnam, obj.subtype or "") for obj in circuits),
+        circuit_parents=tuple((obj.objnam, _cached_optional(obj, "PARENT")) for obj in circuits),
+        group_parent_objnams=group_parents,
+        row_objnams=tuple(row.objnam for row in all_rows),
+        row_topology=tuple(row_topology),
+        inventory=tuple(sorted((obj.objnam, obj.objtype) for obj in model)),
+    )
+
+
+def build_projection_query() -> dict[str, Any]:
+    """Return the fixed-size wildcard safety projection request."""
+    from .controller import MAX_ATTRIBUTES_PER_QUERY
+
+    if len(PROJECTION_KEYS) > MAX_ATTRIBUTES_PER_QUERY:
+        raise ICError("Color Sync projection exceeds the protocol query limit")
+    return {
+        "condition": "",
+        "objectList": [{"objnam": "INCR", "keys": list(PROJECTION_KEYS)}],
+    }
+
+
+def build_subscription_batches(topology: LightGroupTopology) -> list[list[dict[str, Any]]]:
+    """Build deterministic exact-object subscription batches under the key limit."""
+    from .controller import MAX_ATTRIBUTES_PER_QUERY
+
+    entries: list[dict[str, Any]] = [
+        {"objnam": topology.system_objnam, "keys": ["OBJTYP", "VER", "SERVICE"]}
+    ]
+    groups = set(topology.group_parent_objnams)
+    for objnam in topology.circuit_objnams:
+        keys = ["OBJTYP", "SUBTYP", "PARENT", "STATUS", "USE"]
+        if objnam in groups:
+            keys.extend(ACTION_FLAGS)
+        entries.append({"objnam": objnam, "keys": keys})
+    for objnam in topology.row_objnams:
+        entries.append(
+            {"objnam": objnam, "keys": ["OBJTYP", "PARENT", "CIRCUIT", "LISTORD", "USE"]}
+        )
+
+    batches: list[list[dict[str, Any]]] = []
+    batch: list[dict[str, Any]] = []
+    count = 0
+    for entry in entries:
+        size = len(entry["keys"])
+        if size > MAX_ATTRIBUTES_PER_QUERY:
+            raise ICError("Color Sync subscription entry exceeds the protocol query limit")
+        if batch and count + size > MAX_ATTRIBUTES_PER_QUERY:
+            batches.append(batch)
+            batch = []
+            count = 0
+        batch.append(entry)
+        count += size
+    if batch:
+        batches.append(batch)
+    return batches
+
+
+def _raw_entries(response: Any) -> dict[str, tuple[str, dict[str, Any]]]:
+    if not isinstance(response, dict):
+        raise ICError("Color Sync projection response is malformed")
+    object_list = response.get("objectList")
+    if not isinstance(object_list, list):
+        raise ICError("Color Sync projection objectList is malformed")
+    entries: dict[str, tuple[str, dict[str, Any]]] = {}
+    for raw in object_list:
+        if not isinstance(raw, dict):
+            raise ICError("Color Sync projection entry is malformed")
+        objnam = raw.get("objnam")
+        params = raw.get("params")
+        if not isinstance(objnam, str) or not objnam or not isinstance(params, dict):
+            raise ICError("Color Sync projection identity is malformed")
+        if objnam in entries:
+            raise ICError("Color Sync projection contains a duplicate object")
+        objtype = _real_value(params, "OBJTYP")
+        entries[objnam] = (objtype, params)
+    return entries
+
+
+def parse_projection(
+    response: dict[str, Any],
+    topology: LightGroupTopology,
+) -> LightGroupProjection:
+    """Parse and normalize one complete authoritative wildcard projection."""
+    entries = _raw_entries(response)
+    expected_relevant = {
+        topology.system_objnam,
+        *topology.circuit_objnams,
+        *topology.row_objnams,
+    }
+    actual_relevant = {name for name, (objtype, _) in entries.items() if objtype in RELEVANT_TYPES}
+    if actual_relevant != expected_relevant:
+        raise ICError("Color Sync fresh topology differs from the cached model")
+
+    system_type, system_params = entries[topology.system_objnam]
+    if system_type != "SYSTEM":
+        raise ICError("Color Sync system type changed")
+    system = _SystemProjection(
+        topology.system_objnam,
+        system_type,
+        _real_value(system_params, "VER"),
+        _real_value(system_params, "SERVICE"),
+    )
+
+    cached_subtypes = dict(topology.circuit_subtypes)
+    cached_parents = dict(topology.circuit_parents)
+    circuits: list[_CircuitProjection] = []
+    for objnam in topology.circuit_objnams:
+        objtype, params = entries[objnam]
+        subtype = _real_value(params, "SUBTYP")
+        parent = _normalize_optional("PARENT", params.get("PARENT"), present="PARENT" in params)
+        if (
+            objtype != "CIRCUIT"
+            or subtype != cached_subtypes[objnam]
+            or parent != cached_parents[objnam]
+        ):
+            raise ICError("Color Sync fresh circuit topology differs from the cache")
+        circuits.append(
+            _CircuitProjection(
+                objnam,
+                objtype,
+                subtype,
+                parent,
+                _real_value(params, "STATUS"),
+                _normalize_optional("USE", params.get("USE"), present="USE" in params),
+            )
+        )
+
+    group_states: list[_GroupProjection] = []
+    for objnam in topology.group_parent_objnams:
+        params = entries[objnam][1]
+        group_states.append(
+            _GroupProjection(
+                objnam,
+                _real_value(params, "SYNC"),
+                _real_value(params, "SET"),
+                _real_value(params, "SWIM"),
+            )
+        )
+
+    cached_rows = {row[0]: row for row in topology.row_topology}
+    rows: list[_RowProjection] = []
+    for objnam in topology.row_objnams:
+        objtype, params = entries[objnam]
+        parent = _real_value(params, "PARENT")
+        circuit = _real_value(params, "CIRCUIT")
+        listord = _real_value(params, "LISTORD")
+        if objtype != "CIRCGRP" or (objnam, parent, circuit, listord) != cached_rows[objnam]:
+            raise ICError("Color Sync fresh membership topology differs from the cache")
+        rows.append(
+            _RowProjection(
+                objnam,
+                objtype,
+                parent,
+                circuit,
+                listord,
+                _normalize_optional("USE", params.get("USE"), present="USE" in params),
+            )
+        )
+
+    return LightGroupProjection(system, tuple(circuits), tuple(group_states), tuple(rows))
+
+
+def validate_initial_projection(
+    projection: LightGroupProjection,
+    topology: LightGroupTopology,
+) -> Literal["ON", "OFF"]:
+    """Validate the uniform prestate and return it."""
+    if projection.system.version != SUPPORTED_FIRMWARE or projection.system.service != "AUTO":
+        raise ICError("Color Sync fresh firmware/service gate failed")
+    if any(
+        (group.sync, group.set_value, group.swim) != ("OFF", "OFF", "OFF")
+        for group in projection.groups
+    ):
+        raise ICError("Color Sync requires every group action flag to be OFF")
+    circuits = {item.objnam: item for item in projection.circuits}
+    target_names = (topology.target_objnam, *topology.target_children)
+    statuses = tuple(circuits[name].status for name in target_names)
+    if statuses not in {("ON", "ON", "ON"), ("OFF", "OFF", "OFF")}:
+        raise ICError("Color Sync requires a canonical uniform target prestate")
+    return statuses[0]  # type: ignore[return-value]
+
+
+def validate_final_projection(
+    final: LightGroupProjection,
+    baseline: LightGroupProjection,
+    topology: LightGroupTopology,
+) -> None:
+    """Require the exact baseline invariants plus target completion state."""
+    if final.system != baseline.system or final.rows != baseline.rows:
+        raise ICError("Color Sync final projection changed system or membership topology")
+    baseline_circuits = {item.objnam: item for item in baseline.circuits}
+    target_names = {topology.target_objnam, *topology.target_children}
+    for circuit in final.circuits:
+        old = baseline_circuits.get(circuit.objnam)
+        if old is None:
+            raise ICError("Color Sync final circuit inventory changed")
+        if (
+            circuit.objtype != old.objtype
+            or circuit.subtype != old.subtype
+            or circuit.parent != old.parent
+            or circuit.use != old.use
+            or (circuit.objnam in target_names and circuit.status != "ON")
+            or (circuit.objnam not in target_names and circuit.status != old.status)
+        ):
+            raise ICError("Color Sync final circuit projection mismatch")
+    baseline_groups = {item.objnam: item for item in baseline.groups}
+    for group in final.groups:
+        old_group = baseline_groups.get(group.objnam)
+        if old_group is None:
+            raise ICError("Color Sync final group inventory changed")
+        if group.objnam == topology.target_objnam:
+            if (
+                group.sync != "OFF"
+                or group.set_value != old_group.set_value
+                or group.swim != old_group.swim
+            ):
+                raise ICError("Color Sync target flags did not return to baseline")
+        elif group != old_group:
+            raise ICError("Color Sync unrelated group flags changed")
+
+
+def _projection_values(projection: LightGroupProjection) -> dict[str, dict[str, str | None]]:
+    values: dict[str, dict[str, str | None]] = {
+        projection.system.objnam: {
+            "OBJTYP": projection.system.objtype,
+            "VER": projection.system.version,
+            "SERVICE": projection.system.service,
+        }
+    }
+    for circuit in projection.circuits:
+        values[circuit.objnam] = {
+            "OBJTYP": circuit.objtype,
+            "SUBTYP": circuit.subtype,
+            "PARENT": circuit.parent,
+            "STATUS": circuit.status,
+            "USE": circuit.use,
+        }
+    for group in projection.groups:
+        values[group.objnam].update(
+            {"SYNC": group.sync, "SET": group.set_value, "SWIM": group.swim}
+        )
+    for row in projection.rows:
+        values[row.objnam] = {
+            "OBJTYP": row.objtype,
+            "PARENT": row.parent,
+            "CIRCUIT": row.circuit,
+            "LISTORD": row.listord,
+            "USE": row.use,
+        }
+    return values
+
+
+def validate_subscription_response(
+    response: dict[str, Any],
+    request: list[dict[str, Any]],
+    baseline: LightGroupProjection,
+    _topology: LightGroupTopology,
+) -> None:
+    """Validate exact initialization coverage and normalized baseline equality."""
+    if (
+        response.get("response") != "200"
+        or not isinstance(response.get("messageID"), str)
+        or not response["messageID"]
+    ):
+        raise ICError("Color Sync subscription was not acknowledged")
+    object_list = response.get("objectList")
+    if not isinstance(object_list, list) or not object_list:
+        raise ICError("Color Sync subscription initialization is malformed")
+    requested = {item["objnam"]: tuple(item["keys"]) for item in request}
+    actual: dict[str, dict[str, Any]] = {}
+    for entry in object_list:
+        if not isinstance(entry, dict):
+            raise ICError("Color Sync subscription entry is malformed")
+        objnam = entry.get("objnam")
+        params = entry.get("params")
+        if not isinstance(objnam, str) or objnam in actual or not isinstance(params, dict):
+            raise ICError("Color Sync subscription identity is malformed")
+        if objnam not in requested or set(params) - set(requested[objnam]):
+            raise ICError("Color Sync subscription contains unexpected coverage")
+        actual[objnam] = params
+    if set(actual) != set(requested):
+        raise ICError("Color Sync subscription is missing an object")
+
+    expected = _projection_values(baseline)
+    for objnam, keys in requested.items():
+        params = actual[objnam]
+        objtype = expected[objnam]["OBJTYP"]
+        for key in keys:
+            optional = (objtype, key) in OPTIONAL_FIELDS
+            if key not in params and not optional:
+                raise ICError("Color Sync subscription is missing a mandatory key")
+            if optional:
+                value = _normalize_optional(key, params.get(key), present=key in params)
+            else:
+                value = _real_value(params, key)
+            if value != expected[objnam][key]:
+                raise ICError("Color Sync subscription initialization differs from baseline")
+
+
+class LightGroupSyncTracker:
+    """Edge-qualified monotonic action and invariant tracker."""
+
+    def __init__(self, topology: LightGroupTopology) -> None:
+        self.topology = topology
+        self.failure_event = asyncio.Event()
+        self.write_started = asyncio.Event()
+        self.watermark_ready = asyncio.Event()
+        self.onset_event = asyncio.Event()
+        self.terminal_event = asyncio.Event()
+        self.failure: ICError | None = None
+        self.baseline: LightGroupProjection | None = None
+        self.prebaseline: list[tuple[int, dict[str, Any]]] = []
+        self.dynamic_types = dict(topology.inventory)
+        self.pre_send_sequence: int | None = None
+        self.watermark: int | None = None
+        self.write_started_at: float | None = None
+        self.action_deadline: float | None = None
+        self.terminal_time: float | None = None
+        self.response_received = False
+        self.acknowledged = False
+        self.initial_status: Literal["ON", "OFF"] | None = None
+        self.turned_on: set[str] = set()
+
+    @property
+    def onset_seen(self) -> bool:
+        return self.onset_event.is_set()
+
+    def _record_failure(self, error: ICError) -> None:
+        if self.failure is None:
+            self.failure = error
+            self.failure_event.set()
+
+    def raise_if_failed(self) -> None:
+        if self.failure is not None:
+            raise self.failure
+
+    def set_prewrite_baseline(self, projection: LightGroupProjection) -> None:
+        self.baseline = projection
+        self.initial_status = validate_initial_projection(projection, self.topology)
+        if self.initial_status == "ON":
+            self.turned_on.update((self.topology.target_objnam, *self.topology.target_children))
+        buffered, self.prebaseline = self.prebaseline, []
+        for sequence, frame in buffered:
+            self._observe_frame(sequence, frame)
+
+    def observe(self, sequence: int, frame: dict[str, Any]) -> None:
+        if self.failure is not None:
+            return
+        if self.baseline is None:
+            self._observe_frame(sequence, frame, compare_baseline=False)
+            if self.failure is not None:
+                return
+            if len(self.prebaseline) >= MAX_PREBASELINE_NOTIFICATIONS:
+                self._record_failure(
+                    ICError("Color Sync pre-baseline notification buffer overflow")
+                )
+                return
+            self.prebaseline.append((sequence, copy.deepcopy(frame)))
+            return
+        self._observe_frame(sequence, frame)
+
+    def _observe_frame(
+        self,
+        sequence: int,
+        frame: dict[str, Any],
+        *,
+        compare_baseline: bool = True,
+    ) -> None:
+        try:
+            object_list = frame.get("objectList") if isinstance(frame, dict) else None
+            if not isinstance(object_list, list):
+                raise ICError("Malformed Color Sync notification objectList")
+            for entry in object_list:
+                self._observe_entry(sequence, entry, compare_baseline=compare_baseline)
+        except ICError as err:
+            self._record_failure(err)
+        except (KeyError, TypeError, ValueError) as err:
+            self._record_failure(ICError(f"Malformed Color Sync notification: {err}"))
+
+    def _observe_entry(
+        self,
+        sequence: int,
+        entry: Any,
+        *,
+        compare_baseline: bool,
+    ) -> None:
+        if not isinstance(entry, dict):
+            raise ICError("Malformed Color Sync notification entry")
+        objnam = entry.get("objnam")
+        params = entry.get("params")
+        if not isinstance(objnam, str) or not objnam or not isinstance(params, dict):
+            raise ICError("Malformed Color Sync notification identity")
+
+        known_type = self.dynamic_types.get(objnam)
+        announced_type_present = "OBJTYP" in params
+        announced_type = params.get("OBJTYP")
+        if announced_type_present and (
+            not isinstance(announced_type, str)
+            or not announced_type
+            or announced_type == "OBJTYP"
+            or announced_type == "00000"
+        ):
+            raise ICError("Malformed Color Sync notification object type")
+        if known_type is None:
+            if announced_type in RELEVANT_TYPES or (
+                not announced_type_present and bool(set(params) & set(PROJECTION_KEYS))
+            ):
+                raise ICError("Color Sync notification introduced ambiguous topology")
+            if announced_type_present:
+                assert isinstance(announced_type, str)
+                self.dynamic_types[objnam] = announced_type
+            return
+        if known_type not in RELEVANT_TYPES:
+            if announced_type in RELEVANT_TYPES:
+                raise ICError("Color Sync notification changed object relevance")
+            if announced_type_present:
+                assert isinstance(announced_type, str)
+                self.dynamic_types[objnam] = announced_type
+            return
+        if announced_type_present and announced_type != known_type:
+            raise ICError("Color Sync notification changed object type")
+
+        if compare_baseline:
+            assert self.baseline is not None
+            expected = _projection_values(self.baseline)[objnam]
+            expected_keys = set(expected)
+        elif known_type == "SYSTEM":
+            expected = None
+            expected_keys = {"OBJTYP", "VER", "SERVICE"}
+        elif known_type == "CIRCUIT":
+            expected = None
+            expected_keys = {"OBJTYP", "SUBTYP", "PARENT", "STATUS", "USE"}
+            if objnam in self.topology.group_parent_objnams:
+                expected_keys.update(ACTION_FLAGS)
+        else:
+            expected = None
+            expected_keys = {"OBJTYP", "PARENT", "CIRCUIT", "LISTORD", "USE"}
+        target_names = {self.topology.target_objnam, *self.topology.target_children}
+        for key, raw_value in params.items():
+            if key not in expected_keys:
+                continue
+            optional = (known_type, key) in OPTIONAL_FIELDS
+            if optional:
+                value = _normalize_optional(key, raw_value)
+            else:
+                if (
+                    not isinstance(raw_value, str)
+                    or not raw_value
+                    or raw_value == key
+                    or raw_value == "00000"
+                ):
+                    raise ICError(f"Malformed mandatory notification {key}")
+                value = raw_value
+
+            if not compare_baseline:
+                if key == "STATUS" and objnam in target_names and value not in {"ON", "OFF"}:
+                    raise ICError("Color Sync target status is noncanonical")
+                if (
+                    key == "SYNC"
+                    and objnam == self.topology.target_objnam
+                    and value
+                    not in {
+                        "ON",
+                        "OFF",
+                    }
+                ):
+                    raise ICError("Color Sync target SYNC is noncanonical")
+                continue
+
+            if not self.write_started.is_set():
+                assert expected is not None
+                if value != expected[key]:
+                    raise ICError(f"Color Sync invariant changed: {objnam}.{key}")
+                continue
+
+            if key == "STATUS" and objnam in target_names:
+                self._observe_target_status(objnam, value)
+                continue
+            if key == "SYNC" and objnam == self.topology.target_objnam:
+                self._observe_target_sync(sequence, value)
+                continue
+            assert expected is not None
+            if value != expected[key]:
+                raise ICError(f"Color Sync invariant changed: {objnam}.{key}")
+
+    def _observe_target_status(self, objnam: str, value: str | None) -> None:
+        if value not in {"ON", "OFF"}:
+            raise ICError("Color Sync target status is noncanonical")
+        if self.initial_status == "ON" and value == "OFF":
+            raise ICError("Color Sync all-on target turned off")
+        if value == "ON":
+            self.turned_on.add(objnam)
+        elif objnam in self.turned_on:
+            raise ICError("Color Sync target returned off after reaching on")
+
+    def _observe_target_sync(self, sequence: int, value: str | None) -> None:
+        if value not in {"ON", "OFF"}:
+            raise ICError("Color Sync target SYNC is noncanonical")
+        if (
+            not self.watermark_ready.is_set()
+            or self.watermark is None
+            or sequence <= self.watermark
+        ):
+            return
+        if self.terminal_event.is_set():
+            if value == "ON":
+                raise ICError("Color Sync target SYNC re-entered after terminal")
+            return
+        if not self.onset_event.is_set():
+            if value == "ON":
+                self.onset_event.set()
+            return
+        if value == "OFF":
+            self.terminal_time = asyncio.get_running_loop().time()
+            self.terminal_event.set()
+
+    def mark_before_write(self, sequence: int, started_at: float) -> None:
+        self.raise_if_failed()
+        self.pre_send_sequence = sequence
+        self.write_started_at = started_at
+        self.action_deadline = started_at + SYNC_ACTION_DEADLINE_SECONDS
+        self.write_started.set()
+
+    def mark_after_write(self, sequence: int) -> None:
+        self.watermark = sequence
+        self.watermark_ready.set()
+
+
+async def _cancel_and_await(task: asyncio.Task[Any] | None) -> None:
+    if task is None:
+        return
+    if not task.done():
+        task.cancel()
+    with contextlib.suppress(BaseException):
+        await task
+
+
+async def _wait_deadline(deadline: float) -> None:
+    async with asyncio.timeout_at(deadline):
+        await asyncio.Event().wait()
+
+
+async def _sleep_until(deadline: float) -> None:
+    delay = max(0.0, deadline - asyncio.get_running_loop().time())
+    await asyncio.sleep(delay)
+
+
+def _closed_error() -> ICConnectionError:
+    return ICConnectionError("Color Sync captured connection closed")
+
+
+def _phase_for_tracker(
+    tracker: LightGroupSyncTracker,
+    fallback: Literal["acknowledgement", "onset", "terminal", "observation", "final_projection"],
+) -> Literal["acknowledgement", "onset", "terminal", "observation", "final_projection"]:
+    if not tracker.response_received or not tracker.acknowledged:
+        return "acknowledgement"
+    if not tracker.onset_event.is_set():
+        return "onset"
+    if not tracker.terminal_event.is_set():
+        return "terminal"
+    return fallback
+
+
+def _wrap_post_dispatch(
+    tracker: LightGroupSyncTracker,
+    error: Exception,
+    phase: Literal["acknowledgement", "onset", "terminal", "observation", "final_projection"],
+) -> ICLightGroupError:
+    return ICLightGroupError(
+        str(error),
+        phase=_phase_for_tracker(tracker, phase),
+        response_received=tracker.response_received,
+        acknowledged=tracker.acknowledged,
+        onset_seen=tracker.onset_seen,
+    )
+
+
+async def run_light_group_sync(
+    controller: _CircuitGroupMixin,
+    group_objnam: str,
+) -> dict[str, Any]:
+    """Run one verified, non-retried Color Sync lifecycle."""
+    build_topology(controller, group_objnam)
+    tracker: LightGroupSyncTracker | None = None
+    remover: Callable[[], None] | None = None
+    owned_tasks: set[asyncio.Task[Any]] = set()
+    phase: Literal["acknowledgement", "onset", "terminal", "observation", "final_projection"] = (
+        "acknowledgement"
+    )
+
+    async def cleanup_inside_lifecycle() -> None:
+        if remover is not None:
+            remover()
+        tasks = tuple(owned_tasks)
+        for task in tasks:
+            if not task.done():
+                task.cancel()
+        for task in tasks:
+            with contextlib.suppress(BaseException):
+                await task
+
+    try:
+        async with contextlib.AsyncExitStack() as stack:
+            lease = await stack.enter_async_context(controller._light_group_mutation_lifecycle())
+            stack.push_async_callback(cleanup_inside_lifecycle)
+            topology = build_topology(controller, group_objnam)
+            connection = controller._connection
+            if connection is None or not connection.connected:
+                raise ICConnectionError("Not connected")
+            connection_closed = connection._capture_closed_future()
+            projection_query = build_projection_query()
+            subscription_batches = build_subscription_batches(topology)
+            tracker = LightGroupSyncTracker(topology)
+            failure_task = asyncio.create_task(tracker.failure_event.wait())
+            owned_tasks.add(failure_task)
+
+            def observer(sequence: int, frame: dict[str, Any]) -> None:
+                if connection_closed.done():
+                    tracker._record_failure(_closed_error())
+                    return
+                tracker.observe(sequence, frame)
+
+            remover = connection.add_notification_observer(observer)
+
+            def closed_before_send(_sequence: int, _started_at: float) -> None:
+                if connection_closed.done():
+                    raise _closed_error()
+
+            async def guarded(operation: Coroutine[Any, Any, Any]) -> Any:
+                task: asyncio.Task[Any] = asyncio.create_task(operation)
+                owned_tasks.add(task)
+                done, _ = await asyncio.wait(
+                    {task, connection_closed, failure_task},
+                    return_when=asyncio.FIRST_COMPLETED,
+                )
+                if connection_closed in done:
+                    await _cancel_and_await(task)
+                    raise _closed_error()
+                if failure_task in done:
+                    await _cancel_and_await(task)
+                    tracker.raise_if_failed()
+                try:
+                    result = await task
+                except BaseException as error:
+                    if connection_closed.done():
+                        raise _closed_error() from error
+                    tracker.raise_if_failed()
+                    raise
+                if connection_closed.done():
+                    raise _closed_error()
+                tracker.raise_if_failed()
+                return result
+
+            async def request(
+                command: str,
+                extra: dict[str, Any],
+                *,
+                request_timeout: float | None = None,
+                before: Callable[[int, float], None] | None = closed_before_send,
+                after: Callable[[int], None] | None = None,
+            ) -> dict[str, Any]:
+                return await controller._send_cmd_on_connection_unlocked(
+                    connection,
+                    command,
+                    extra,
+                    _mutation_lease=lease,
+                    request_timeout=request_timeout,
+                    _before_write_callback=before,
+                    _after_write_callback=after,
+                )
+
+            first_response = await guarded(request("GetParamList", projection_query))
+            baseline = parse_projection(first_response, topology)
+            tracker.set_prewrite_baseline(baseline)
+            tracker.raise_if_failed()
+
+            for batch in subscription_batches:
+                response = await guarded(request("RequestParamList", {"objectList": batch}))
+                validate_subscription_response(response, batch, baseline, topology)
+                tracker.raise_if_failed()
+
+            await guarded(asyncio.sleep(SUBSCRIPTION_SETTLE_SECONDS))
+            second_response = await guarded(request("GetParamList", projection_query))
+            second = parse_projection(second_response, topology)
+            if second != baseline:
+                raise ICError("Color Sync preflight mismatch after subscription settle")
+            tracker.raise_if_failed()
+
+            def mark_before(sequence: int, started_at: float) -> None:
+                if connection_closed.done():
+                    raise _closed_error()
+                tracker.mark_before_write(sequence, started_at)
+
+            action_task = asyncio.create_task(
+                request(
+                    "SetParamList",
+                    {"objectList": [{"objnam": group_objnam, "params": {"SYNC": "ON"}}]},
+                    request_timeout=SYNC_ACTION_DEADLINE_SECONDS,
+                    before=mark_before,
+                    after=tracker.mark_after_write,
+                )
+            )
+            owned_tasks.add(action_task)
+            write_waiter = asyncio.create_task(tracker.write_started.wait())
+            owned_tasks.add(write_waiter)
+            initial_wait_set: set[asyncio.Future[Any]] = {
+                action_task,
+                write_waiter,
+                connection_closed,
+                failure_task,
+            }
+            initial_done, _ = await asyncio.wait(
+                initial_wait_set,
+                return_when=asyncio.FIRST_COMPLETED,
+            )
+            if connection_closed in initial_done:
+                await _cancel_and_await(action_task)
+                raise _closed_error()
+            if failure_task in initial_done:
+                await _cancel_and_await(action_task)
+                tracker.raise_if_failed()
+            if connection_closed.done():
+                await _cancel_and_await(action_task)
+                raise _closed_error()
+            if tracker.failure is not None:
+                await _cancel_and_await(action_task)
+                tracker.raise_if_failed()
+            if action_task in initial_done and not tracker.write_started.is_set():
+                try:
+                    await action_task
+                except BaseException as error:
+                    if connection_closed.done():
+                        raise _closed_error() from error
+                    tracker.raise_if_failed()
+                    raise
+                if connection_closed.done():
+                    raise _closed_error()
+                tracker.raise_if_failed()
+                raise ICError("Color Sync action completed before transport dispatch")
+
+            if tracker.action_deadline is None:
+                raise ICError("Color Sync dispatch deadline was not initialized")
+            if asyncio.get_running_loop().time() >= tracker.action_deadline:
+                raise ICError("Color Sync action deadline expired")
+            deadline_task = asyncio.create_task(_wait_deadline(tracker.action_deadline))
+            watermark_waiter = asyncio.create_task(tracker.watermark_ready.wait())
+            onset_waiter = asyncio.create_task(tracker.onset_event.wait())
+            terminal_waiter = asyncio.create_task(tracker.terminal_event.wait())
+            owned_tasks.update({deadline_task, watermark_waiter, onset_waiter, terminal_waiter})
+            action_processed = False
+            acknowledgement: dict[str, Any] | None = None
+            phase = "acknowledgement"
+            while not (
+                tracker.acknowledged
+                and tracker.onset_event.is_set()
+                and tracker.terminal_event.is_set()
+            ):
+                wait_set: set[asyncio.Future[Any]] = {
+                    connection_closed,
+                    failure_task,
+                    deadline_task,
+                }
+                if not action_processed:
+                    wait_set.add(action_task)
+                if not tracker.watermark_ready.is_set():
+                    wait_set.add(watermark_waiter)
+                if not tracker.onset_event.is_set():
+                    wait_set.add(onset_waiter)
+                if not tracker.terminal_event.is_set():
+                    wait_set.add(terminal_waiter)
+                action_done, _ = await asyncio.wait(wait_set, return_when=asyncio.FIRST_COMPLETED)
+                if connection_closed in action_done:
+                    raise _closed_error()
+                if failure_task in action_done:
+                    tracker.raise_if_failed()
+                if connection_closed.done():
+                    raise _closed_error()
+                tracker.raise_if_failed()
+                if (
+                    deadline_task in action_done
+                    or asyncio.get_running_loop().time() >= tracker.action_deadline
+                ):
+                    with contextlib.suppress(Exception):
+                        deadline_task.exception()
+                    raise ICError("Color Sync action deadline expired")
+                if action_task in action_done and not action_processed:
+                    action_processed = True
+                    try:
+                        acknowledgement = await action_task
+                    except ICCommandError as error:
+                        tracker.response_received = True
+                        if connection_closed.done():
+                            raise _closed_error() from error
+                        tracker.raise_if_failed()
+                        raise
+                    except BaseException as error:
+                        if connection_closed.done():
+                            raise _closed_error() from error
+                        tracker.raise_if_failed()
+                        raise
+                    tracker.response_received = True
+                    if connection_closed.done():
+                        raise _closed_error()
+                    tracker.raise_if_failed()
+                    if (
+                        acknowledgement.get("response") != "200"
+                        or not isinstance(acknowledgement.get("messageID"), str)
+                        or not acknowledgement["messageID"]
+                    ):
+                        raise ICError("Color Sync acknowledgement is malformed")
+                    tracker.acknowledged = True
+                if connection_closed.done():
+                    raise _closed_error()
+                tracker.raise_if_failed()
+                if asyncio.get_running_loop().time() >= tracker.action_deadline:
+                    raise ICError("Color Sync action deadline expired")
+                phase = _phase_for_tracker(tracker, "terminal")
+
+            if not action_processed or acknowledgement is None:
+                raise ICError("Color Sync acknowledgement was not processed")
+
+            phase = "observation"
+            if tracker.terminal_time is None:
+                raise ICError("Color Sync terminal time was not recorded")
+            observation_deadline = tracker.terminal_time + SYNC_POST_TERMINAL_OBSERVATION_SECONDS
+            await guarded(_sleep_until(observation_deadline))
+
+            phase = "final_projection"
+            final_response = await guarded(request("GetParamList", projection_query))
+            final = parse_projection(final_response, topology)
+            validate_final_projection(final, baseline, topology)
+            tracker.raise_if_failed()
+            remover()
+            remover = None
+            return acknowledgement
+    except asyncio.CancelledError:
+        raise
+    except ICLightGroupError:
+        raise
+    except Exception as err:
+        if tracker is not None and tracker.write_started.is_set():
+            raise _wrap_post_dispatch(tracker, err, phase) from err
+        raise

--- a/src/pyintellicenter/_light_group.py
+++ b/src/pyintellicenter/_light_group.py
@@ -110,6 +110,11 @@ class LightGroupProjection:
     rows: tuple[_RowProjection, ...]
 
 
+def _is_sentinel(value: Any, key: str) -> bool:
+    """Return whether a mandatory raw value is missing or a protocol sentinel."""
+    return not isinstance(value, str) or not value or value == key or value == "00000"
+
+
 def _normalize_optional(key: str, value: Any = None, *, present: bool = True) -> str | None:
     if not present or value is None or value == key or value == "00000":
         return None
@@ -120,8 +125,9 @@ def _normalize_optional(key: str, value: Any = None, *, present: bool = True) ->
 
 def _real_value(params: dict[str, Any], key: str) -> str:
     value = params.get(key)
-    if not isinstance(value, str) or not value or value == key or value == "00000":
+    if _is_sentinel(value, key):
         raise ICError(f"Missing or malformed mandatory {key}")
+    assert isinstance(value, str)
     return value
 
 
@@ -511,6 +517,7 @@ class LightGroupSyncTracker:
         self.terminal_event = asyncio.Event()
         self.failure: ICError | None = None
         self.baseline: LightGroupProjection | None = None
+        self._baseline_values: dict[str, dict[str, str | None]] | None = None
         self.prebaseline: list[tuple[int, dict[str, Any]]] = []
         self.dynamic_types = dict(topology.inventory)
         self.pre_send_sequence: int | None = None
@@ -538,6 +545,7 @@ class LightGroupSyncTracker:
 
     def set_prewrite_baseline(self, projection: LightGroupProjection) -> None:
         self.baseline = projection
+        self._baseline_values = _projection_values(projection)
         self.initial_status = validate_initial_projection(projection, self.topology)
         if self.initial_status == "ON":
             self.turned_on.update((self.topology.target_objnam, *self.topology.target_children))
@@ -596,12 +604,7 @@ class LightGroupSyncTracker:
         known_type = self.dynamic_types.get(objnam)
         announced_type_present = "OBJTYP" in params
         announced_type = params.get("OBJTYP")
-        if announced_type_present and (
-            not isinstance(announced_type, str)
-            or not announced_type
-            or announced_type == "OBJTYP"
-            or announced_type == "00000"
-        ):
+        if announced_type_present and _is_sentinel(announced_type, "OBJTYP"):
             raise ICError("Malformed Color Sync notification object type")
         if known_type is None:
             if announced_type in RELEVANT_TYPES or (
@@ -623,8 +626,8 @@ class LightGroupSyncTracker:
             raise ICError("Color Sync notification changed object type")
 
         if compare_baseline:
-            assert self.baseline is not None
-            expected = _projection_values(self.baseline)[objnam]
+            assert self._baseline_values is not None
+            expected = self._baseline_values[objnam]
             expected_keys = set(expected)
         elif known_type == "SYSTEM":
             expected = None
@@ -645,12 +648,7 @@ class LightGroupSyncTracker:
             if optional:
                 value = _normalize_optional(key, raw_value)
             else:
-                if (
-                    not isinstance(raw_value, str)
-                    or not raw_value
-                    or raw_value == key
-                    or raw_value == "00000"
-                ):
+                if _is_sentinel(raw_value, key):
                     raise ICError(f"Malformed mandatory notification {key}")
                 value = raw_value
 

--- a/src/pyintellicenter/_light_group.py
+++ b/src/pyintellicenter/_light_group.py
@@ -6,7 +6,7 @@ import asyncio
 import contextlib
 import copy
 from dataclasses import dataclass
-from typing import TYPE_CHECKING, Any, Literal
+from typing import TYPE_CHECKING, Any, Literal, cast
 
 from .exceptions import (
     ICCommandError,
@@ -379,7 +379,7 @@ def validate_initial_projection(
     statuses = tuple(circuits[name].status for name in target_names)
     if statuses not in {("ON", "ON", "ON"), ("OFF", "OFF", "OFF")}:
         raise ICError("Color Sync requires a canonical uniform target prestate")
-    return statuses[0]  # type: ignore[return-value]
+    return cast('Literal["ON", "OFF"]', statuses[0])
 
 
 def validate_final_projection(

--- a/src/pyintellicenter/_mixins/_base.py
+++ b/src/pyintellicenter/_mixins/_base.py
@@ -24,6 +24,11 @@ from __future__ import annotations
 from typing import TYPE_CHECKING, Any
 
 if TYPE_CHECKING:
+    import asyncio
+    from collections.abc import Callable
+    from contextlib import AbstractAsyncContextManager
+
+    from ..connection import ICConnection, TransportType
     from ..controller import ICSystemInfo
     from ..model import PoolModel
 
@@ -42,6 +47,11 @@ if TYPE_CHECKING:
 
         _model: PoolModel
         _system_info: ICSystemInfo | None
+        _connection: ICConnection | None
+        _mutation_lock: asyncio.Lock
+        _mutation_owner: asyncio.Task[Any] | None
+        _light_group_mutation_pending: bool
+        _light_group_mutation_lease: object | None
 
         @property
         def system_info(self) -> ICSystemInfo | None:
@@ -64,6 +74,33 @@ if TYPE_CHECKING:
 
         async def send_cmd(self, cmd: str, extra: dict[str, Any] | None = None) -> dict[str, Any]:
             """Send a command and return the response (provided by ``ICBaseController``)."""
+            raise NotImplementedError
+
+        def _mutation_lifecycle(self) -> AbstractAsyncContextManager[None]:
+            """Return the ordinary object-writer lifecycle context."""
+            raise NotImplementedError
+
+        def _light_group_mutation_lifecycle(self) -> AbstractAsyncContextManager[object]:
+            """Return the exclusive Color Sync lifecycle context."""
+            raise NotImplementedError
+
+        @property
+        def transport(self) -> TransportType:
+            """Return the configured connection transport."""
+            raise NotImplementedError
+
+        async def _send_cmd_on_connection_unlocked(
+            self,
+            connection: ICConnection,
+            cmd: str,
+            extra: dict[str, Any] | None = None,
+            *,
+            _mutation_lease: object,
+            request_timeout: float | None = None,
+            _before_write_callback: Callable[[int, float], None] | None = None,
+            _after_write_callback: Callable[[int], None] | None = None,
+        ) -> dict[str, Any]:
+            """Send on the captured connection using the active Sync lease."""
             raise NotImplementedError
 
 else:

--- a/src/pyintellicenter/_mixins/circuit_group.py
+++ b/src/pyintellicenter/_mixins/circuit_group.py
@@ -8,71 +8,145 @@ from __future__ import annotations
 
 from typing import TYPE_CHECKING
 
-from ..attributes import CIRCGRP_TYPE, CIRCUIT_ATTR
+from ..attributes import (
+    CIRCGRP_TYPE,
+    CIRCUIT_ATTR,
+    CIRCUIT_TYPE,
+    LISTORD_ATTR,
+    PARENT_ATTR,
+)
 from ._base import _MixinBase
 
 if TYPE_CHECKING:
     from ..model import PoolObject
 
 
+_GROUP_PARENT_SUBTYPES = frozenset({"CIRCGRP", "LITSHO"})
+
+
+def _is_group_parent(obj: PoolObject) -> bool:
+    """Return whether an object has a supported circuit-group parent shape."""
+    return obj.objtype == CIRCUIT_TYPE and obj.subtype in _GROUP_PARENT_SUBTYPES
+
+
+def _member_order(member: PoolObject) -> tuple[int, int, str]:
+    """Sort valid nonnegative list orders before a deterministic malformed tail."""
+    value = member[LISTORD_ATTR]
+    try:
+        order = int(value)
+    except (TypeError, ValueError):
+        return (1, 0, member.objnam)
+    if order < 0:
+        return (1, 0, member.objnam)
+    return (0, order, member.objnam)
+
+
 class _CircuitGroupMixin(_MixinBase):
     """Circuit group convenience methods for ``ICModelController``."""
 
     def get_circuit_groups(self) -> list[PoolObject]:
-        """Get all circuit group objects.
+        """Get all circuit objects that act as group parents.
 
-        Circuit groups allow multiple circuits to be controlled together.
-        Groups containing color lights can have light effects applied.
+        ``CIRCGRP`` objects are membership rows and are not returned here.
 
         Returns:
-            List of PoolObject for circuit groups
+            List of circuit-group parent objects
         """
-        return self._model.get_by_type(CIRCGRP_TYPE)
+        return [obj for obj in self._model if _is_group_parent(obj)]
 
-    def get_circuits_in_group(self, circgrp_objnam: str) -> list[PoolObject]:
-        """Get all circuit objects that belong to a circuit group.
+    def get_circuit_group_members(self, parent_objnam: str) -> list[PoolObject]:
+        """Get the ordered membership rows for a circuit-group parent.
 
         Args:
-            circgrp_objnam: Object name of the circuit group
+            parent_objnam: Object name of the circuit-group parent
 
         Returns:
-            List of PoolObject for circuits in the group
+            Membership rows sorted by valid LISTORD, then object name
         """
-        obj = self._model[circgrp_objnam]
-        if not obj or obj.objtype != CIRCGRP_TYPE:
+        return sorted(
+            (
+                obj
+                for obj in self._model.get_by_type(CIRCGRP_TYPE)
+                if obj[PARENT_ATTR] == parent_objnam
+            ),
+            key=_member_order,
+        )
+
+    def get_circuits_in_group(self, group_or_row_objnam: str) -> list[PoolObject]:
+        """Get the resolved circuits for a parent or membership row.
+
+        A real membership row resolves all ordered siblings through its parent.
+        For compatibility, a standalone legacy row can directly list one or
+        more circuit object names.
+
+        Args:
+            group_or_row_objnam: Object name of a group parent or membership row
+
+        Returns:
+            Existing circuit references in deterministic membership order
+        """
+        obj = self._model[group_or_row_objnam]
+        if not obj:
             return []
 
-        circuit_ref = obj[CIRCUIT_ATTR]
-        if not circuit_ref:
+        parent: PoolObject | None
+        if _is_group_parent(obj):
+            parent = obj
+        elif obj.objtype == CIRCGRP_TYPE:
+            if PARENT_ATTR not in obj.attribute_keys:
+                return self._get_legacy_circuits_in_group(obj)
+
+            parent_ref = obj[PARENT_ATTR]
+            if not isinstance(parent_ref, str) or not parent_ref:
+                return []
+            parent = self._model[parent_ref]
+            if not parent or not _is_group_parent(parent):
+                return []
+        else:
             return []
 
-        # CIRCUIT attribute can be a single objnam or space-separated list
-        circuit_objnams = circuit_ref.split() if isinstance(circuit_ref, str) else [circuit_ref]
+        circuits: list[PoolObject] = []
+        for member in self.get_circuit_group_members(parent.objnam):
+            circuit_ref = member[CIRCUIT_ATTR]
+            if not isinstance(circuit_ref, str) or not circuit_ref:
+                continue
+            if any(character.isspace() for character in circuit_ref):
+                continue
+            circuit = self._model[circuit_ref]
+            if circuit:
+                circuits.append(circuit)
+        return circuits
 
-        circuits = []
-        for objnam in circuit_objnams:
+    def _get_legacy_circuits_in_group(self, row: PoolObject) -> list[PoolObject]:
+        """Resolve an exact legacy standalone membership-row fixture."""
+        circuit_ref = row[CIRCUIT_ATTR]
+        if not isinstance(circuit_ref, str):
+            return []
+
+        circuits: list[PoolObject] = []
+        for objnam in circuit_ref.split():
             circuit = self._model[objnam]
             if circuit:
                 circuits.append(circuit)
         return circuits
 
-    def circuit_group_has_color_lights(self, circgrp_objnam: str) -> bool:
+    def circuit_group_has_color_lights(self, parent_objnam: str) -> bool:
         """Check if a circuit group contains any color-capable lights.
 
         Circuit groups that contain IntelliBrite, MagicStream, or other
         color lights can have light effects applied to the entire group.
 
         Args:
-            circgrp_objnam: Object name of the circuit group
+            parent_objnam: Object name of the circuit-group parent
 
         Returns:
             True if the group contains at least one color light
         """
-        circuits = self.get_circuits_in_group(circgrp_objnam)
+        circuits = self.get_circuits_in_group(parent_objnam)
         return any(circuit.supports_color_effects for circuit in circuits)
 
     def get_color_light_groups(self) -> list[PoolObject]:
-        """Get circuit groups that contain color-capable lights.
+        """Get real circuit-group parents that contain color-capable lights.
 
         These groups can have light effects applied via set_light_effect().
 

--- a/src/pyintellicenter/_mixins/circuit_group.py
+++ b/src/pyintellicenter/_mixins/circuit_group.py
@@ -6,7 +6,7 @@ contain color-capable lights can have light effects applied to the whole group.
 
 from __future__ import annotations
 
-from typing import TYPE_CHECKING
+from typing import TYPE_CHECKING, Any
 
 from ..attributes import (
     CIRCGRP_TYPE,
@@ -53,6 +53,12 @@ class _CircuitGroupMixin(_MixinBase):
             List of circuit-group parent objects
         """
         return [obj for obj in self._model if _is_group_parent(obj)]
+
+    async def run_light_group_sync(self, group_objnam: str) -> dict[str, Any]:
+        """Run the evidence-bounded Color Sync action for one light group."""
+        from .._light_group import run_light_group_sync
+
+        return await run_light_group_sync(self, group_objnam)
 
     def get_circuit_group_members(self, parent_objnam: str) -> list[PoolObject]:
         """Get the ordered membership rows for a circuit-group parent.

--- a/src/pyintellicenter/connection.py
+++ b/src/pyintellicenter/connection.py
@@ -24,6 +24,7 @@ import asyncio
 import contextlib
 import inspect
 import logging
+from dataclasses import dataclass, field
 from typing import TYPE_CHECKING, Any, Literal, Protocol, runtime_checkable
 
 import orjson
@@ -35,7 +36,10 @@ if TYPE_CHECKING:
     from collections.abc import Awaitable, Callable
 
     # Callback types
+    AfterWriteCallback = Callable[[int], None]
+    BeforeWriteCallback = Callable[[int, float], None]
     NotificationCallback = Callable[[dict[str, Any]], None | Awaitable[None]]
+    NotificationObserver = Callable[[int, dict[str, Any]], None]
     DisconnectCallback = Callable[[Exception | None], None]
 
 _LOGGER = logging.getLogger(__name__)
@@ -55,6 +59,14 @@ DEFAULT_NOTIFICATION_QUEUE_SIZE = 100  # max queued notifications
 DEFAULT_PORT = DEFAULT_TCP_PORT
 
 
+@dataclass(slots=True)
+class _NotificationObserverState:
+    """Connection-owned sequence and additive raw notification observers."""
+
+    sequence: int = 0
+    observers: list[NotificationObserver] = field(default_factory=list)
+
+
 @runtime_checkable
 class ICTransportProtocol(Protocol):
     """Protocol defining the transport interface.
@@ -72,6 +84,9 @@ class ICTransportProtocol(Protocol):
         self,
         command: str,
         request_timeout: float = RESPONSE_TIMEOUT,
+        *,
+        _before_write_callback: BeforeWriteCallback | None = None,
+        _after_write_callback: AfterWriteCallback | None = None,
         **kwargs: Any,
     ) -> dict[str, Any]:
         """Send a request and await response."""
@@ -144,11 +159,13 @@ class ICNotificationMixin:
     _notification_queue_size: int
     _notification_queue: asyncio.Queue[dict[str, Any]] | None
     _consumer_task: asyncio.Task[None] | None
+    _notification_observer_state: _NotificationObserverState
 
     def _init_notification_mixin(
         self,
         notification_callback: NotificationCallback | None,
         notification_queue_size: int,
+        notification_observer_state: _NotificationObserverState | None,
     ) -> None:
         """Initialize notification handling state."""
         self._notification_callback = notification_callback
@@ -158,6 +175,11 @@ class ICNotificationMixin:
         self._notification_queue_size = notification_queue_size
         self._notification_queue = None
         self._consumer_task = None
+        self._notification_observer_state = (
+            notification_observer_state
+            if notification_observer_state is not None
+            else _NotificationObserverState()
+        )
 
     def _start_notification_consumer(self) -> None:
         """Start the notification consumer task if not already running."""
@@ -193,6 +215,14 @@ class ICNotificationMixin:
 
     def _handle_notification(self, msg: dict[str, Any]) -> None:
         """Handle a NotifyList notification by queuing for processing."""
+        state = self._notification_observer_state
+        sequence = state.sequence = state.sequence + 1
+        for observer in tuple(state.observers):
+            try:
+                observer(sequence, msg)
+            except Exception:
+                _LOGGER.exception("Error in notification observer")
+
         if not self._notification_callback or self._notification_queue is None:
             return
 
@@ -253,6 +283,7 @@ class ICProtocol(ICRequestMixin, ICNotificationMixin, asyncio.Protocol):
         disconnect_callback: DisconnectCallback | None = None,
         *,
         notification_queue_size: int = DEFAULT_NOTIFICATION_QUEUE_SIZE,
+        notification_observer_state: _NotificationObserverState | None = None,
     ) -> None:
         """Initialize the protocol.
 
@@ -262,7 +293,11 @@ class ICProtocol(ICRequestMixin, ICNotificationMixin, asyncio.Protocol):
             notification_queue_size: Max queued notifications (default: 100)
         """
         self._init_request_mixin()
-        self._init_notification_mixin(notification_callback, notification_queue_size)
+        self._init_notification_mixin(
+            notification_callback,
+            notification_queue_size,
+            notification_observer_state,
+        )
         self._disconnect_callback = disconnect_callback
 
         # Transport (set by connection_made)
@@ -334,6 +369,9 @@ class ICProtocol(ICRequestMixin, ICNotificationMixin, asyncio.Protocol):
         self,
         command: str,
         request_timeout: float = RESPONSE_TIMEOUT,
+        *,
+        _before_write_callback: BeforeWriteCallback | None = None,
+        _after_write_callback: AfterWriteCallback | None = None,
         **kwargs: Any,
     ) -> dict[str, Any]:
         """Send a request and await response via Future."""
@@ -353,7 +391,14 @@ class ICProtocol(ICRequestMixin, ICNotificationMixin, asyncio.Protocol):
 
         try:
             packet = orjson.dumps(request) + b"\r\n"
+            if _before_write_callback is not None:
+                _before_write_callback(
+                    self._notification_observer_state.sequence,
+                    asyncio.get_running_loop().time(),
+                )
             self._transport.write(packet)
+            if _after_write_callback is not None:
+                _after_write_callback(self._notification_observer_state.sequence)
             _LOGGER.debug("Sent TCP request: %s (ID: %s)", command, msg_id)
 
             async with asyncio.timeout(request_timeout):
@@ -392,6 +437,7 @@ class ICWebSocketTransport(ICRequestMixin, ICNotificationMixin):
         disconnect_callback: DisconnectCallback | None = None,
         *,
         notification_queue_size: int = DEFAULT_NOTIFICATION_QUEUE_SIZE,
+        notification_observer_state: _NotificationObserverState | None = None,
     ) -> None:
         """Initialize the WebSocket transport.
 
@@ -401,7 +447,11 @@ class ICWebSocketTransport(ICRequestMixin, ICNotificationMixin):
             notification_queue_size: Max queued notifications (default: 100)
         """
         self._init_request_mixin()
-        self._init_notification_mixin(notification_callback, notification_queue_size)
+        self._init_notification_mixin(
+            notification_callback,
+            notification_queue_size,
+            notification_observer_state,
+        )
         self._disconnect_callback = disconnect_callback
 
         self._ws: Any = None  # websockets.WebSocketClientProtocol
@@ -518,6 +568,9 @@ class ICWebSocketTransport(ICRequestMixin, ICNotificationMixin):
         self,
         command: str,
         request_timeout: float = RESPONSE_TIMEOUT,
+        *,
+        _before_write_callback: BeforeWriteCallback | None = None,
+        _after_write_callback: AfterWriteCallback | None = None,
         **kwargs: Any,
     ) -> dict[str, Any]:
         """Send a request and await response."""
@@ -538,7 +591,14 @@ class ICWebSocketTransport(ICRequestMixin, ICNotificationMixin):
         try:
             # Send as text with \r\n terminator (same framing as TCP)
             packet = orjson.dumps(request).decode() + "\r\n"
+            if _before_write_callback is not None:
+                _before_write_callback(
+                    self._notification_observer_state.sequence,
+                    asyncio.get_running_loop().time(),
+                )
             await self._ws.send(packet)
+            if _after_write_callback is not None:
+                _after_write_callback(self._notification_observer_state.sequence)
             _LOGGER.debug("Sent WebSocket request: %s (ID: %s)", command, msg_id)
 
             async with asyncio.timeout(request_timeout):
@@ -658,9 +718,16 @@ class ICConnection:
         # Callbacks
         self._notification_callback: NotificationCallback | None = None
         self._disconnect_callback: DisconnectCallback | None = None
+        self._notification_observer_state = _NotificationObserverState()
+
+        # One-shot lifecycle signal for the current connection generation
+        self._closed_future: asyncio.Future[None] | None = None
 
         # Flow control: one request at a time
         self._request_lock = asyncio.Lock()
+
+        # Connection lifecycle: one generation attempt at a time
+        self._connect_lock = asyncio.Lock()
 
         # Keepalive task
         self._keepalive_task: asyncio.Task[None] | None = None
@@ -711,6 +778,27 @@ class ICConnection:
             if callback and self._protocol.connected and self._protocol._notification_queue is None:
                 self._protocol._start_notification_consumer()
 
+    def add_notification_observer(
+        self,
+        observer: NotificationObserver,
+    ) -> Callable[[], None]:
+        """Add an enqueue-time notification observer and return its remover."""
+        state = self._notification_observer_state
+        state.observers.append(observer)
+        removed = False
+
+        def remove() -> None:
+            nonlocal removed
+            if removed:
+                return
+            removed = True
+            for index, candidate in enumerate(state.observers):
+                if candidate is observer:
+                    del state.observers[index]
+                    break
+
+        return remove
+
     def set_disconnect_callback(self, callback: DisconnectCallback | None) -> None:
         """Set callback for disconnection events.
 
@@ -721,6 +809,25 @@ class ICConnection:
 
     def _on_disconnect(self, exc: Exception | None) -> None:
         """Internal disconnect handler that wraps user callback."""
+        closed_future = self._closed_future
+        if closed_future is not None:
+            self._on_generation_disconnect(closed_future, exc)
+            return
+        self._handle_current_disconnect(exc)
+
+    def _on_generation_disconnect(
+        self,
+        closed_future: asyncio.Future[None],
+        exc: Exception | None,
+    ) -> None:
+        """Handle a transport close only for the generation that emitted it."""
+        self._complete_closed_future(closed_future)
+        if closed_future is not self._closed_future:
+            return
+        self._handle_current_disconnect(exc)
+
+    def _handle_current_disconnect(self, exc: Exception | None) -> None:
+        """Cancel current lifecycle work and dispatch an unexpected close."""
         if self._keepalive_task and not self._keepalive_task.done():
             self._keepalive_task.cancel()
             self._keepalive_task = None
@@ -744,6 +851,7 @@ class ICConnection:
         transport's disconnect callback first so the transport's own teardown
         (e.g. TCP connection_lost after close()) cannot fire it again later.
         """
+        self._complete_closed_future()
         protocol, self._protocol = self._protocol, None
         if protocol is not None:
             protocol._disconnect_callback = None
@@ -759,13 +867,40 @@ class ICConnection:
         Raises:
             ICConnectionError: If connection fails or times out.
         """
+        async with self._connect_lock:
+            await self._connect_locked()
+
+    async def _connect_locked(self) -> None:
+        """Establish one serialized connection generation."""
         if self.connected:
             return
 
-        if self._transport_type == "websocket":
-            await self._connect_websocket()
-        else:
-            await self._connect_tcp()
+        closed_future = asyncio.get_running_loop().create_future()
+        self._closed_future = closed_future
+
+        def on_disconnect(exc: Exception | None) -> None:
+            self._on_generation_disconnect(closed_future, exc)
+
+        try:
+            if self._transport_type == "websocket":
+                await self._connect_websocket(on_disconnect)
+            else:
+                await self._connect_tcp(on_disconnect)
+
+            if self._closed_future is not closed_future:
+                raise ICConnectionError("Connection generation changed during setup")
+            if closed_future.done() or not self.connected:
+                protocol, self._protocol = self._protocol, None
+                if protocol is not None:
+                    protocol._disconnect_callback = None
+                    protocol.close()
+                raise ICConnectionError("Connection closed during setup")
+        except asyncio.CancelledError:
+            self._complete_closed_future(closed_future)
+            raise
+        except Exception:
+            self._complete_closed_future(closed_future)
+            raise
 
         # Fresh connection - its disconnect may dispatch (again)
         self._disconnect_dispatched = False
@@ -773,7 +908,7 @@ class ICConnection:
         # Start keepalive task
         self._keepalive_task = asyncio.create_task(self._keepalive_loop())
 
-    async def _connect_tcp(self) -> None:
+    async def _connect_tcp(self, disconnect_callback: DisconnectCallback) -> None:
         """Establish TCP connection."""
         try:
             loop = asyncio.get_running_loop()
@@ -782,8 +917,9 @@ class ICConnection:
                 _, protocol = await loop.create_connection(
                     lambda: ICProtocol(
                         notification_callback=self._notification_callback,
-                        disconnect_callback=self._on_disconnect,
+                        disconnect_callback=disconnect_callback,
                         notification_queue_size=self._notification_queue_size,
+                        notification_observer_state=self._notification_observer_state,
                     ),
                     self._host,
                     self._port,
@@ -801,12 +937,13 @@ class ICConnection:
                 f"Failed to connect to {self._host}:{self._port}: {err}"
             ) from err
 
-    async def _connect_websocket(self) -> None:
+    async def _connect_websocket(self, disconnect_callback: DisconnectCallback) -> None:
         """Establish WebSocket connection."""
         transport = ICWebSocketTransport(
             notification_callback=self._notification_callback,
-            disconnect_callback=self._on_disconnect,
+            disconnect_callback=disconnect_callback,
             notification_queue_size=self._notification_queue_size,
+            notification_observer_state=self._notification_observer_state,
         )
         await transport.connect(self._host, self._port)
         self._protocol = transport
@@ -814,17 +951,37 @@ class ICConnection:
 
     async def disconnect(self) -> None:
         """Close the connection gracefully."""
+        self._complete_closed_future()
+        protocol, self._protocol = self._protocol, None
+        if protocol is not None:
+            protocol._disconnect_callback = None
+
         if self._keepalive_task and not self._keepalive_task.done():
             self._keepalive_task.cancel()
             with contextlib.suppress(asyncio.CancelledError):
                 await self._keepalive_task
             self._keepalive_task = None
 
-        if self._protocol:
-            self._protocol.close()
-            self._protocol = None
+        if protocol is not None:
+            protocol.close()
 
         _LOGGER.debug("Disconnected from IC")
+
+    def _complete_closed_future(
+        self,
+        future: asyncio.Future[None] | None = None,
+    ) -> None:
+        """Complete a generation's close signal once."""
+        future = future if future is not None else self._closed_future
+        if future is not None and not future.done():
+            future.set_result(None)
+
+    def _capture_closed_future(self) -> asyncio.Future[None]:
+        """Return the one-shot close future for the current live generation."""
+        future = self._closed_future
+        if future is None or not self.connected:
+            raise ICConnectionError("Connection is not live")
+        return future
 
     async def __aenter__(self) -> ICConnection:
         """Async context manager entry."""
@@ -839,6 +996,9 @@ class ICConnection:
         self,
         command: str,
         request_timeout: float | None = None,
+        *,
+        _before_write_callback: BeforeWriteCallback | None = None,
+        _after_write_callback: AfterWriteCallback | None = None,
         **kwargs: Any,
     ) -> dict[str, Any]:
         """Send a request and wait for the response.
@@ -865,7 +1025,11 @@ class ICConnection:
 
         async with self._request_lock:
             return await self._protocol.send_request(
-                command, request_timeout=effective_timeout, **kwargs
+                command,
+                request_timeout=effective_timeout,
+                _before_write_callback=_before_write_callback,
+                _after_write_callback=_after_write_callback,
+                **kwargs,
             )
 
     async def _keepalive_loop(self) -> None:

--- a/src/pyintellicenter/controller.py
+++ b/src/pyintellicenter/controller.py
@@ -1045,9 +1045,12 @@ class ICModelController(
 
         if not request.future.done():
             request.future.cancel()
-        if request.future.cancelled():
-            with contextlib.suppress(asyncio.CancelledError):
-                request.future.exception()
+        # Cancellation can arrive after another flush detached this request and
+        # completed its future with either a result or an exception. Always
+        # retrieve the terminal state so a caller-level CancelledError cannot
+        # orphan a completed exception warning.
+        with contextlib.suppress(asyncio.CancelledError):
+            request.future.exception()
 
     async def _flush_pending_changes(self, owner_request: _PendingRequest) -> None:
         """Flush all pending changes in a single batch request.
@@ -1094,9 +1097,8 @@ class ICModelController(
                 # CancelledError; peers receive one stable uncertainty failure.
                 if not owner_request.future.done():
                     owner_request.future.cancel()
-                if owner_request.future.cancelled():
-                    with contextlib.suppress(asyncio.CancelledError):
-                        owner_request.future.exception()
+                with contextlib.suppress(asyncio.CancelledError):
+                    owner_request.future.exception()
                 uncertainty = ICError(
                     "Coalesced mutation delivery is unknown after flush cancellation"
                 )

--- a/src/pyintellicenter/controller.py
+++ b/src/pyintellicenter/controller.py
@@ -253,10 +253,11 @@ from .attributes import (
     HeaterType as HeaterType,
 )
 from .connection import DEFAULT_TCP_PORT, DEFAULT_WEBSOCKET_PORT, ICConnection, TransportType
-from .exceptions import ICCommandError, ICConnectionError, ICResponseError, ICTimeoutError
+from .exceptions import ICCommandError, ICConnectionError, ICError, ICResponseError, ICTimeoutError
 
 if TYPE_CHECKING:
-    from collections.abc import Callable
+    from collections.abc import AsyncIterator, Callable
+    from contextlib import AbstractAsyncContextManager
 
     from .model import PoolModel, PoolObject
     from .types import ObjectEntry
@@ -297,6 +298,7 @@ class _PendingRequest:
     with the latest value winning.
     """
 
+    changes: dict[str, dict[str, str]]
     future: asyncio.Future[dict[str, Any]] = field(default_factory=asyncio.Future)
 
 
@@ -438,6 +440,15 @@ class ICBaseController:
         # Metrics
         self._metrics = ICConnectionMetrics()
 
+        # Object writes share one controller-wide mutation lifecycle. Color Sync
+        # marks its long-running lifecycle pending before waiting for older
+        # admitted writers, then authorizes its captured-connection requests with
+        # one unforgeable identity token.
+        self._mutation_lock = asyncio.Lock()
+        self._mutation_owner: asyncio.Task[Any] | None = None
+        self._light_group_mutation_pending = False
+        self._light_group_mutation_lease: object | None = None
+
     def __repr__(self) -> str:
         return (
             f"ICBaseController(host={self._host!r}, port={self._port}, "
@@ -554,16 +565,118 @@ class ICBaseController:
         Returns:
             Response dictionary
 
+        Mutation boundary:
+            Case-insensitive ``SetParamList`` is the controller's supported
+            object-writer command. Once Color Sync marks its mutation lifecycle
+            pending, later same-controller object writes fail immediately and
+            must be retried deliberately; they are never queued for replay after
+            Sync. Read-only commands continue. Undocumented vendor writers and a
+            separately constructed raw ``ICConnection`` are outside this
+            controller boundary.
+
         Raises:
             ICConnectionError: If not connected
             ICCommandError: If command fails
         """
-        if not self._connection or not self._connection.connected:
-            raise ICConnectionError("Not connected")
+        is_object_writer = cmd.casefold() == "setparamlist"
+        if is_object_writer and self._light_group_mutation_pending:
+            raise ICError("Color Sync mutation lifecycle is in progress")
+
+        async def _send_on_current_connection() -> dict[str, Any]:
+            connection = self._connection
+            if connection is None or not connection.connected:
+                raise ICConnectionError("Not connected")
+
+            with _RequestContext(self._metrics):
+                try:
+                    return await connection.send_request(cmd, **(extra or {}))
+                except ICResponseError as err:
+                    raise ICCommandError(err.code) from err
+
+        if not is_object_writer:
+            return await _send_on_current_connection()
+
+        async with self._mutation_lifecycle():
+            return await _send_on_current_connection()
+
+    def _mutation_lifecycle(self) -> AbstractAsyncContextManager[None]:
+        """Serialize an ordinary object writer and record its owning task."""
+
+        @contextlib.asynccontextmanager
+        async def _lifecycle() -> AsyncIterator[None]:
+            await self._mutation_lock.acquire()
+            self._mutation_owner = asyncio.current_task()
+            try:
+                yield
+            finally:
+                self._mutation_owner = None
+                self._mutation_lock.release()
+
+        return _lifecycle()
+
+    def _light_group_mutation_lifecycle(self) -> AbstractAsyncContextManager[object]:
+        """Own the exclusive Color Sync lifecycle and yield its opaque lease."""
+
+        @contextlib.asynccontextmanager
+        async def _lifecycle() -> AsyncIterator[object]:
+            if self._light_group_mutation_pending:
+                raise ICError("Color Sync mutation lifecycle is in progress")
+
+            # No await may occur between admission and this mark: later public and
+            # coalesced writers must observe the lifecycle immediately.
+            self._light_group_mutation_pending = True
+            acquired = False
+            try:
+                await self._mutation_lock.acquire()
+                acquired = True
+                self._mutation_owner = asyncio.current_task()
+                lease = object()
+                self._light_group_mutation_lease = lease
+                yield lease
+            finally:
+                if acquired:
+                    # Callers must cancel and await delegated children before
+                    # leaving this context. Invalidate authorization before
+                    # releasing the lifecycle to a later writer.
+                    self._light_group_mutation_lease = None
+                    self._mutation_owner = None
+                    self._mutation_lock.release()
+                self._light_group_mutation_pending = False
+
+        return _lifecycle()
+
+    async def _send_cmd_on_connection_unlocked(
+        self,
+        connection: ICConnection,
+        cmd: str,
+        extra: dict[str, Any] | None = None,
+        *,
+        _mutation_lease: object,
+        request_timeout: float | None = None,
+        _before_write_callback: Callable[[int, float], None] | None = None,
+        _after_write_callback: Callable[[int], None] | None = None,
+    ) -> dict[str, Any]:
+        """Send on the captured connection under the active opaque Sync lease."""
+        if (
+            not self._light_group_mutation_pending
+            or not self._mutation_lock.locked()
+            or self._mutation_owner is None
+            or self._light_group_mutation_lease is None
+            or self._light_group_mutation_lease is not _mutation_lease
+        ):
+            raise ICError("Invalid or inactive Color Sync mutation lease")
+        if self._connection is not connection or not connection.connected:
+            raise ICConnectionError("Connection changed or is not connected")
 
         with _RequestContext(self._metrics):
             try:
-                return await self._connection.send_request(cmd, **(extra or {}))
+                return await connection.send_request(
+                    cmd,
+                    request_timeout=request_timeout,
+                    _before_write_callback=_before_write_callback,
+                    _after_write_callback=_after_write_callback,
+                    **(extra or {}),
+                )
             except ICResponseError as err:
                 raise ICCommandError(err.code) from err
 
@@ -888,23 +1001,55 @@ class ICModelController(
         Returns:
             Response dictionary from the batched request
         """
-        # Create a future for this request
-        request = _PendingRequest()
+        if self._light_group_mutation_pending:
+            raise ICError("Color Sync mutation lifecycle is in progress")
+
+        owned_changes = {objnam: dict(changes)}
+        request = _PendingRequest(owned_changes)
 
         # Merge changes into pending (latest value wins for same objnam+attr)
         if objnam not in self._pending_changes:
             self._pending_changes[objnam] = {}
-        self._pending_changes[objnam].update(changes)
+        self._pending_changes[objnam].update(owned_changes[objnam])
 
         # Track this request so it gets notified when batch completes
         self._pending_requests.append(request)
 
         # Try to flush - if lock is held, we wait and our changes get batched
-        await self._flush_pending_changes()
+        try:
+            await self._flush_pending_changes(request)
+            return await request.future
+        except asyncio.CancelledError:
+            self._remove_pending_request(request)
+            raise
 
-        return await request.future
+    def _rebuild_pending_changes(self) -> None:
+        """Rebuild latest-wins aggregation from requests still awaiting detach."""
+        rebuilt: dict[str, dict[str, str]] = {}
+        for request in self._pending_requests:
+            for objnam, attrs in request.changes.items():
+                rebuilt.setdefault(objnam, {}).update(attrs)
+        self._pending_changes = rebuilt
 
-    async def _flush_pending_changes(self) -> None:
+    def _remove_pending_request(self, request: _PendingRequest) -> None:
+        """Remove one not-yet-detached request without leaving a live future."""
+        removed = False
+        for index, pending in enumerate(self._pending_requests):
+            if pending is request:
+                self._pending_requests.pop(index)
+                removed = True
+                break
+
+        if removed:
+            self._rebuild_pending_changes()
+
+        if not request.future.done():
+            request.future.cancel()
+        if request.future.cancelled():
+            with contextlib.suppress(asyncio.CancelledError):
+                request.future.exception()
+
+    async def _flush_pending_changes(self, owner_request: _PendingRequest) -> None:
         """Flush all pending changes in a single batch request.
 
         Only one flush runs at a time. While one is in progress, new requests
@@ -937,7 +1082,23 @@ class ICModelController(
                 for req in requests:
                     if not req.future.done():
                         req.future.set_result(response)
-            except (ICConnectionError, ICCommandError, ICTimeoutError, OSError) as e:
+            except asyncio.CancelledError:
+                # The transport may already have accepted this batch. Never
+                # requeue or retry it. The cancelled initiating caller keeps its
+                # CancelledError; peers receive one stable uncertainty failure.
+                if not owner_request.future.done():
+                    owner_request.future.cancel()
+                if owner_request.future.cancelled():
+                    with contextlib.suppress(asyncio.CancelledError):
+                        owner_request.future.exception()
+                uncertainty = ICError(
+                    "Coalesced mutation delivery is unknown after flush cancellation"
+                )
+                for req in requests:
+                    if req is not owner_request and not req.future.done():
+                        req.future.set_exception(uncertainty)
+                raise
+            except (ICError, OSError) as e:
                 # Propagate error to all waiters
                 for req in requests:
                     if not req.future.done():
@@ -997,17 +1158,25 @@ class ICModelController(
         Returns:
             Response dictionary from the batched request
         """
-        request = _PendingRequest()
+        if self._light_group_mutation_pending:
+            raise ICError("Color Sync mutation lifecycle is in progress")
+
+        owned_changes = {objnam: dict(attrs) for objnam, attrs in changes.items()}
+        request = _PendingRequest(owned_changes)
 
         # Merge all changes into pending
-        for objnam, attrs in changes.items():
+        for objnam, attrs in owned_changes.items():
             if objnam not in self._pending_changes:
                 self._pending_changes[objnam] = {}
             self._pending_changes[objnam].update(attrs)
 
         self._pending_requests.append(request)
-        await self._flush_pending_changes()
-        return await request.future
+        try:
+            await self._flush_pending_changes(request)
+            return await request.future
+        except asyncio.CancelledError:
+            self._remove_pending_request(request)
+            raise
 
     def _get_attr_as_int(self, objnam: str, attr: str) -> int | None:
         """Get an attribute value as an integer, or None if unavailable."""

--- a/src/pyintellicenter/controller.py
+++ b/src/pyintellicenter/controller.py
@@ -1056,6 +1056,12 @@ class ICModelController(
         queue up and will be sent in the next batch.
         """
         async with self._coalesce_lock:
+            # Another flush may already have detached and completed this
+            # caller's request while it waited for the coalescing lock. Such a
+            # caller must observe its own future next; it cannot detach or send
+            # work admitted by a later caller.
+            if not any(request is owner_request for request in self._pending_requests):
+                return
             if not self._pending_changes:
                 return
 

--- a/src/pyintellicenter/exceptions.py
+++ b/src/pyintellicenter/exceptions.py
@@ -6,6 +6,16 @@ making it easier to catch and handle specific error types.
 
 from __future__ import annotations
 
+from typing import Literal
+
+type _LightGroupPhase = Literal[
+    "acknowledgement",
+    "onset",
+    "terminal",
+    "observation",
+    "final_projection",
+]
+
 
 class ICError(Exception):
     """Base exception for all pyintellicenter errors.
@@ -13,6 +23,60 @@ class ICError(Exception):
     All exceptions raised by this library inherit from this class,
     making it easy to catch any library-specific error.
     """
+
+
+class ICLightGroupError(ICError):
+    """A Color Sync failure after transport dispatch began."""
+
+    def __init__(
+        self,
+        message: str,
+        *,
+        phase: _LightGroupPhase,
+        response_received: bool,
+        acknowledged: bool,
+        onset_seen: bool,
+    ) -> None:
+        self._phase = phase
+        self._response_received = response_received
+        self._acknowledged = acknowledged
+        self._onset_seen = onset_seen
+        super().__init__(message)
+
+    @property
+    def phase(self) -> _LightGroupPhase:
+        """Return the lifecycle phase that failed."""
+        return self._phase
+
+    @property
+    def dispatch_started(self) -> bool:
+        """Return whether transport write/send initiation occurred."""
+        return True
+
+    @property
+    def response_received(self) -> bool:
+        """Return whether a correlated controller response arrived."""
+        return self._response_received
+
+    @property
+    def acknowledged(self) -> bool:
+        """Return whether the controller positively acknowledged the action."""
+        return self._acknowledged
+
+    @property
+    def onset_seen(self) -> bool:
+        """Return whether a qualifying post-send-watermark onset was observed."""
+        return self._onset_seen
+
+    def __repr__(self) -> str:
+        return (
+            "ICLightGroupError("
+            f"phase={self.phase!r}, "
+            f"dispatch_started={self.dispatch_started!r}, "
+            f"response_received={self.response_received!r}, "
+            f"acknowledged={self.acknowledged!r}, "
+            f"onset_seen={self.onset_seen!r})"
+        )
 
 
 class ICConnectionError(ICError):

--- a/tests/test_circuit_group.py
+++ b/tests/test_circuit_group.py
@@ -1,0 +1,265 @@
+"""Tests for circuit-group parent and membership-row helpers."""
+
+import pytest
+
+from pyintellicenter import ICModelController, PoolModel
+
+
+@pytest.fixture
+def controller() -> ICModelController:
+    """Create a controller with an empty model."""
+    return ICModelController("192.0.2.1", PoolModel(), 6681)
+
+
+def add_real_group(model: PoolModel) -> None:
+    """Add a hardware-shaped light-group parent and membership rows."""
+    model.add_object("GROUP", {"OBJTYP": "CIRCUIT", "SUBTYP": "LITSHO"})
+    model.add_object(
+        "ROW_B",
+        {
+            "OBJTYP": "CIRCGRP",
+            "PARENT": "GROUP",
+            "CIRCUIT": "CHILD_B",
+            "LISTORD": "2",
+        },
+    )
+    model.add_object(
+        "ROW_BAD",
+        {
+            "OBJTYP": "CIRCGRP",
+            "PARENT": "GROUP",
+            "CIRCUIT": "MISSING",
+            "LISTORD": "bad",
+        },
+    )
+    model.add_object(
+        "ROW_A",
+        {
+            "OBJTYP": "CIRCGRP",
+            "PARENT": "GROUP",
+            "CIRCUIT": "CHILD_A",
+            "LISTORD": "1",
+        },
+    )
+    model.add_object("CHILD_A", {"OBJTYP": "CIRCUIT", "SUBTYP": "GLOW"})
+    model.add_object("CHILD_B", {"OBJTYP": "CIRCUIT", "SUBTYP": "GLOW"})
+
+
+def test_real_group_enumerates_parent_not_members(
+    controller: ICModelController,
+) -> None:
+    add_real_group(controller.model)
+    controller.model.add_object("PLAIN_PARENT", {"OBJTYP": "CIRCUIT", "SUBTYP": "CIRCGRP"})
+    controller.model.add_object("ORPHAN", {"OBJTYP": "CIRCGRP", "CIRCUIT": "CHILD_A"})
+
+    assert [obj.objnam for obj in controller.get_circuit_groups()] == [
+        "GROUP",
+        "PLAIN_PARENT",
+    ]
+
+
+def test_members_are_numeric_order_then_stable_malformed_tail(
+    controller: ICModelController,
+) -> None:
+    add_real_group(controller.model)
+
+    assert [obj.objnam for obj in controller.get_circuit_group_members("GROUP")] == [
+        "ROW_A",
+        "ROW_B",
+        "ROW_BAD",
+    ]
+
+
+def test_duplicate_orders_and_malformed_orders_use_object_name_tiebreaker(
+    controller: ICModelController,
+) -> None:
+    controller.model.add_object(
+        "ROW_VALID_Z",
+        {
+            "OBJTYP": "CIRCGRP",
+            "PARENT": "GROUP",
+            "CIRCUIT": "Z",
+            "LISTORD": "1",
+        },
+    )
+    controller.model.add_object(
+        "ROW_VALID_A",
+        {
+            "OBJTYP": "CIRCGRP",
+            "PARENT": "GROUP",
+            "CIRCUIT": "A",
+            "LISTORD": 1,
+        },
+    )
+    controller.model.add_object(
+        "ROW_MALFORMED_Z",
+        {
+            "OBJTYP": "CIRCGRP",
+            "PARENT": "GROUP",
+            "CIRCUIT": "Z",
+            "LISTORD": "not-a-number",
+        },
+    )
+    controller.model.add_object(
+        "ROW_NEGATIVE",
+        {
+            "OBJTYP": "CIRCGRP",
+            "PARENT": "GROUP",
+            "CIRCUIT": "NEGATIVE",
+            "LISTORD": "-1",
+        },
+    )
+    controller.model.add_object(
+        "ROW_MISSING",
+        {"OBJTYP": "CIRCGRP", "PARENT": "GROUP", "CIRCUIT": "MISSING"},
+    )
+    controller.model.add_object(
+        "ROW_MALFORMED_A",
+        {
+            "OBJTYP": "CIRCGRP",
+            "PARENT": "GROUP",
+            "CIRCUIT": "A",
+            "LISTORD": "bad",
+        },
+    )
+
+    assert [obj.objnam for obj in controller.get_circuit_group_members("GROUP")] == [
+        "ROW_VALID_A",
+        "ROW_VALID_Z",
+        "ROW_MALFORMED_A",
+        "ROW_MALFORMED_Z",
+        "ROW_MISSING",
+        "ROW_NEGATIVE",
+    ]
+
+
+def test_parent_and_real_row_resolve_ordered_sibling_children(
+    controller: ICModelController,
+) -> None:
+    add_real_group(controller.model)
+
+    assert [obj.objnam for obj in controller.get_circuits_in_group("GROUP")] == [
+        "CHILD_A",
+        "CHILD_B",
+    ]
+    assert [obj.objnam for obj in controller.get_circuits_in_group("ROW_B")] == [
+        "CHILD_A",
+        "CHILD_B",
+    ]
+
+
+def test_real_rows_skip_invalid_and_missing_child_references(
+    controller: ICModelController,
+) -> None:
+    controller.model.add_object("GROUP", {"OBJTYP": "CIRCUIT", "SUBTYP": "LITSHO"})
+    controller.model.add_object("CHILD", {"OBJTYP": "CIRCUIT", "SUBTYP": "GLOW"})
+    references = {
+        "ROW_MISSING_KEY": None,
+        "ROW_NON_STRING": 7,
+        "ROW_BLANK": "   ",
+        "ROW_MULTIPLE": "CHILD OTHER",
+        "ROW_UNKNOWN": "UNKNOWN",
+        "ROW_VALID": "CHILD",
+    }
+    for order, (objnam, reference) in enumerate(references.items()):
+        params: dict[str, object] = {
+            "OBJTYP": "CIRCGRP",
+            "PARENT": "GROUP",
+            "LISTORD": str(order),
+        }
+        if objnam != "ROW_MISSING_KEY":
+            params["CIRCUIT"] = reference
+        controller.model.add_object(objnam, params)
+
+    assert [obj.objnam for obj in controller.get_circuits_in_group("GROUP")] == ["CHILD"]
+
+
+@pytest.mark.parametrize("parent", ["MISSING", "", None, 7])
+def test_real_row_requires_valid_group_parent(
+    controller: ICModelController, parent: object
+) -> None:
+    controller.model.add_object("CHILD", {"OBJTYP": "CIRCUIT", "SUBTYP": "GLOW"})
+    controller.model.add_object(
+        "ROW",
+        {"OBJTYP": "CIRCGRP", "PARENT": parent, "CIRCUIT": "CHILD"},
+    )
+
+    assert controller.get_circuits_in_group("ROW") == []
+
+
+@pytest.mark.parametrize(
+    ("objtype", "subtype"),
+    [("CIRCUIT", "GLOW"), ("SYSTEM", None), ("CIRCGRP", None)],
+)
+def test_row_rejects_wrong_parent_type_or_subtype(
+    controller: ICModelController, objtype: str, subtype: str | None
+) -> None:
+    parent_params: dict[str, object] = {"OBJTYP": objtype}
+    if subtype is not None:
+        parent_params["SUBTYP"] = subtype
+    controller.model.add_object("NOT_GROUP", parent_params)
+    controller.model.add_object("CHILD", {"OBJTYP": "CIRCUIT", "SUBTYP": "GLOW"})
+    controller.model.add_object(
+        "ROW",
+        {
+            "OBJTYP": "CIRCGRP",
+            "PARENT": "NOT_GROUP",
+            "CIRCUIT": "CHILD",
+        },
+    )
+
+    assert controller.get_circuits_in_group("NOT_GROUP") == []
+    assert controller.get_circuits_in_group("ROW") == []
+
+
+def test_legacy_standalone_row_resolves_directly_but_is_never_enumerated(
+    controller: ICModelController,
+) -> None:
+    controller.model.add_object("A", {"OBJTYP": "CIRCUIT", "SUBTYP": "GLOW"})
+    controller.model.add_object("B", {"OBJTYP": "CIRCUIT", "SUBTYP": "LIGHT"})
+    controller.model.add_object("LEGACY", {"OBJTYP": "CIRCGRP", "CIRCUIT": "A MISSING B"})
+
+    assert [obj.objnam for obj in controller.get_circuits_in_group("LEGACY")] == [
+        "A",
+        "B",
+    ]
+    assert controller.get_circuit_groups() == []
+    assert controller.get_color_light_groups() == []
+
+
+def test_color_group_results_are_real_parents(
+    controller: ICModelController,
+) -> None:
+    add_real_group(controller.model)
+
+    assert controller.circuit_group_has_color_lights("GROUP") is True
+    assert [obj.objnam for obj in controller.get_color_light_groups()] == ["GROUP"]
+
+
+def test_group_with_only_non_color_lights_is_not_a_color_group(
+    controller: ICModelController,
+) -> None:
+    controller.model.add_object("GROUP", {"OBJTYP": "CIRCUIT", "SUBTYP": "LITSHO"})
+    controller.model.add_object("LIGHT", {"OBJTYP": "CIRCUIT", "SUBTYP": "LIGHT"})
+    controller.model.add_object("DIMMER", {"OBJTYP": "CIRCUIT", "SUBTYP": "DIMMER"})
+    controller.model.add_object(
+        "ROW_LIGHT",
+        {
+            "OBJTYP": "CIRCGRP",
+            "PARENT": "GROUP",
+            "CIRCUIT": "LIGHT",
+            "LISTORD": "1",
+        },
+    )
+    controller.model.add_object(
+        "ROW_DIMMER",
+        {
+            "OBJTYP": "CIRCGRP",
+            "PARENT": "GROUP",
+            "CIRCUIT": "DIMMER",
+            "LISTORD": "2",
+        },
+    )
+
+    assert controller.circuit_group_has_color_lights("GROUP") is False
+    assert controller.get_color_light_groups() == []

--- a/tests/test_connection.py
+++ b/tests/test_connection.py
@@ -1,10 +1,12 @@
 """Tests for pyintellicenter connection module (Protocol-based)."""
 
 import asyncio
-from unittest.mock import MagicMock, patch
+from types import SimpleNamespace
+from unittest.mock import MagicMock, call, patch
 
 import pytest
 
+import pyintellicenter.connection as connection_module
 from pyintellicenter import ICConnection, ICConnectionError, ICResponseError, ICTimeoutError
 from pyintellicenter.connection import (
     CONNECTION_TIMEOUT,
@@ -310,7 +312,7 @@ class TestICConnection:
 
         async def mock_create_connection(protocol_factory, host, port):
             protocol = protocol_factory()
-            protocol._connected = True
+            protocol.connection_made(mock_transport)
             return (mock_transport, protocol)
 
         with patch.object(
@@ -675,6 +677,7 @@ class TestICConnectionTransport:
             await conn.connect()
 
         assert isinstance(conn._protocol, ICWebSocketTransport)
+        assert conn._protocol._notification_observer_state is conn._notification_observer_state
         assert conn.connected is True
 
         await conn.disconnect()
@@ -697,5 +700,640 @@ class TestICConnectionTransport:
             await conn.connect()
 
         assert isinstance(conn._protocol, ICProtocol)
+        assert conn._protocol._notification_observer_state is conn._notification_observer_state
 
         await conn.disconnect()
+
+
+class TestSequencedNotificationObservers:
+    """Tests for connection-owned enqueue-time notification observers."""
+
+    @pytest.mark.asyncio
+    async def test_notification_observer_does_not_replace_primary_callback(self):
+        """The raw observer runs before the existing queued callback."""
+        primary = MagicMock()
+        observer = MagicMock()
+        connection = ICConnection("host")
+        protocol = ICProtocol(
+            notification_callback=primary,
+            notification_observer_state=connection._notification_observer_state,
+        )
+        protocol.connection_made(MagicMock())
+        connection._protocol = protocol
+
+        remove = connection.add_notification_observer(observer)
+        message = {"command": "NotifyList", "objectList": []}
+        protocol._handle_notification(message)
+
+        observer.assert_called_once_with(1, message)
+        primary.assert_not_called()
+        await asyncio.sleep(0)
+        primary.assert_called_once_with(message)
+
+        remove()
+        protocol.connection_lost(None)
+
+    @pytest.mark.asyncio
+    async def test_observer_added_after_enqueue_never_sees_stale_queued_frame(self):
+        """Queue consumption cannot replay an old frame through a new observer."""
+        primary = MagicMock()
+        connection = ICConnection("host")
+        protocol = ICProtocol(
+            notification_callback=primary,
+            notification_observer_state=connection._notification_observer_state,
+        )
+        protocol.connection_made(MagicMock())
+        connection._protocol = protocol
+        stale = {
+            "command": "NotifyList",
+            "objectList": [{"objnam": "OLD", "params": {}}],
+        }
+        fresh = {
+            "command": "NotifyList",
+            "objectList": [{"objnam": "NEW", "params": {}}],
+        }
+        protocol._handle_notification(stale)
+
+        observer = MagicMock()
+        connection.add_notification_observer(observer)
+        await asyncio.sleep(0)
+        observer.assert_not_called()
+
+        protocol._handle_notification(fresh)
+        observer.assert_called_once_with(2, fresh)
+        protocol.connection_lost(None)
+
+    @pytest.mark.asyncio
+    async def test_failing_notification_observer_does_not_block_others_or_primary(self):
+        """Observer failures are isolated from fanout and the primary queue."""
+        primary = MagicMock()
+        failing = MagicMock(side_effect=RuntimeError("observer failed"))
+        healthy = MagicMock()
+        connection = ICConnection("host")
+        protocol = ICProtocol(
+            notification_callback=primary,
+            notification_observer_state=connection._notification_observer_state,
+        )
+        protocol.connection_made(MagicMock())
+        connection._protocol = protocol
+        connection.add_notification_observer(failing)
+        connection.add_notification_observer(healthy)
+        message = {"command": "NotifyList", "objectList": []}
+
+        protocol._handle_notification(message)
+
+        failing.assert_called_once_with(1, message)
+        healthy.assert_called_once_with(1, message)
+        await asyncio.sleep(0)
+        primary.assert_called_once_with(message)
+        protocol.connection_lost(None)
+
+    def test_notification_observer_without_primary_and_idempotent_removal(self):
+        """Raw observers need no primary callback and removal is one-shot."""
+        connection = ICConnection("host")
+        protocol = ICProtocol(
+            notification_observer_state=connection._notification_observer_state,
+        )
+        protocol.connection_made(MagicMock())
+        connection._protocol = protocol
+        observer = MagicMock()
+        remove = connection.add_notification_observer(observer)
+        first = {"command": "NotifyList", "objectList": [{"objnam": "ONE"}]}
+        second = {"command": "NotifyList", "objectList": [{"objnam": "TWO"}]}
+
+        protocol._handle_notification(first)
+        remove()
+        remove()
+        protocol._handle_notification(second)
+
+        observer.assert_called_once_with(1, first)
+
+    def test_notification_observer_sequence_survives_transport_replacement(self):
+        """TCP and WebSocket transports share one connection-owned sequence."""
+        connection = ICConnection("host")
+        observer = MagicMock()
+        connection.add_notification_observer(observer)
+        first = {"command": "NotifyList", "objectList": [{"objnam": "TCP"}]}
+        second = {"command": "NotifyList", "objectList": [{"objnam": "WS"}]}
+
+        tcp = ICProtocol(
+            notification_observer_state=connection._notification_observer_state,
+        )
+        tcp.connection_made(MagicMock())
+        tcp._handle_notification(first)
+
+        websocket = ICWebSocketTransport(
+            notification_observer_state=connection._notification_observer_state,
+        )
+        websocket._connected = True
+        websocket._ws = MagicMock()
+        websocket._handle_notification(second)
+
+        assert tcp._notification_observer_state is connection._notification_observer_state
+        assert websocket._notification_observer_state is connection._notification_observer_state
+        assert observer.call_args_list == [call(1, first), call(2, second)]
+
+
+class TestWriteWatermarks:
+    """Tests for request-lock write-time sequence and clock hooks."""
+
+    @pytest.mark.asyncio
+    async def test_tcp_before_write_and_after_write_watermark_order(self, monkeypatch):
+        """TCP hooks bracket the synchronous write while the request lock is held."""
+        connection = ICConnection("host")
+        protocol = ICProtocol(
+            notification_observer_state=connection._notification_observer_state,
+        )
+        transport = MagicMock()
+        protocol.connection_made(transport)
+        connection._protocol = protocol
+        observer = MagicMock()
+        connection.add_notification_observer(observer)
+        events = []
+        before_values = []
+        after_values = []
+
+        def write(_packet):
+            events.append("write")
+            protocol._handle_response(
+                {
+                    "command": "SendParamList",
+                    "messageID": protocol._pending_message_id,
+                    "response": "200",
+                }
+            )
+
+        transport.write.side_effect = write
+
+        def before_write(sequence, started_at):
+            assert connection._request_lock.locked()
+            events.append("before")
+            before_values.append((sequence, started_at))
+
+        def after_write(sequence):
+            assert connection._request_lock.locked()
+            events.append("after")
+            after_values.append(sequence)
+
+        await connection._request_lock.acquire()
+        request_started = asyncio.Event()
+
+        async def request():
+            request_started.set()
+            return await connection.send_request(
+                "GetParamList",
+                request_timeout=1.0,
+                _before_write_callback=before_write,
+                _after_write_callback=after_write,
+            )
+
+        task = asyncio.create_task(request())
+        await request_started.wait()
+        await asyncio.sleep(0)
+        assert not task.done()
+        blocked_notification = {"command": "NotifyList", "objectList": []}
+        protocol._handle_notification(blocked_notification)
+
+        loop = asyncio.get_running_loop()
+        fake_loop_time = 4321.25
+        monkeypatch.setattr(
+            connection_module,
+            "time",
+            SimpleNamespace(monotonic=lambda: -987654.0),
+            raising=False,
+        )
+        monkeypatch.setattr(loop, "time", lambda: fake_loop_time)
+        connection._request_lock.release()
+        result = await task
+
+        assert result["response"] == "200"
+        assert events == ["before", "write", "after"]
+        assert before_values == [(1, fake_loop_time)]
+        assert after_values == [1]
+        assert before_values[0][1] != connection_module.time.monotonic()
+
+        later_notification = {"command": "NotifyList", "objectList": [{"objnam": "LATER"}]}
+        protocol._handle_notification(later_notification)
+        assert observer.call_args_list == [
+            call(1, blocked_notification),
+            call(2, later_notification),
+        ]
+        assert after_values[0] < 2
+
+    @pytest.mark.asyncio
+    async def test_websocket_suspended_send_updates_after_write_watermark(self, monkeypatch):
+        """The WebSocket after hook includes frames accepted while send is suspended."""
+        connection = ICConnection("host", transport="websocket")
+        websocket = ICWebSocketTransport(
+            notification_observer_state=connection._notification_observer_state,
+        )
+        websocket._connected = True
+        connection._protocol = websocket
+        observer = MagicMock()
+        connection.add_notification_observer(observer)
+        send_entered = asyncio.Event()
+        release_send = asyncio.Event()
+        events = []
+        before_values = []
+        after_values = []
+
+        class SuspendedWebSocket:
+            async def send(self, _packet):
+                events.append("send-start")
+                send_entered.set()
+                await release_send.wait()
+                events.append("send-end")
+                websocket._handle_response(
+                    {
+                        "command": "SendParamList",
+                        "messageID": websocket._pending_message_id,
+                        "response": "200",
+                    }
+                )
+
+        websocket._ws = SuspendedWebSocket()
+
+        def before_write(sequence, started_at):
+            assert connection._request_lock.locked()
+            events.append("before")
+            before_values.append((sequence, started_at))
+
+        def after_write(sequence):
+            assert connection._request_lock.locked()
+            events.append("after")
+            after_values.append(sequence)
+
+        await connection._request_lock.acquire()
+        request_started = asyncio.Event()
+
+        async def request():
+            request_started.set()
+            return await connection.send_request(
+                "GetParamList",
+                request_timeout=1.0,
+                _before_write_callback=before_write,
+                _after_write_callback=after_write,
+            )
+
+        task = asyncio.create_task(request())
+        await request_started.wait()
+        await asyncio.sleep(0)
+        assert not task.done()
+        blocked_notification = {"command": "NotifyList", "objectList": [{"objnam": "BLOCKED"}]}
+        websocket._handle_notification(blocked_notification)
+
+        loop = asyncio.get_running_loop()
+        fake_loop_time = 7654.5
+        monkeypatch.setattr(
+            connection_module,
+            "time",
+            SimpleNamespace(monotonic=lambda: -123456.0),
+            raising=False,
+        )
+        monkeypatch.setattr(loop, "time", lambda: fake_loop_time)
+        connection._request_lock.release()
+        await send_entered.wait()
+        during_send = {"command": "NotifyList", "objectList": [{"objnam": "DURING"}]}
+        websocket._handle_notification(during_send)
+        release_send.set()
+        result = await task
+
+        assert result["response"] == "200"
+        assert events == ["before", "send-start", "send-end", "after"]
+        assert before_values == [(1, fake_loop_time)]
+        assert after_values == [2]
+        assert before_values[0][0] < 2 <= after_values[0]
+        assert before_values[0][1] != connection_module.time.monotonic()
+
+        later_notification = {"command": "NotifyList", "objectList": [{"objnam": "LATER"}]}
+        websocket._handle_notification(later_notification)
+        assert observer.call_args_list == [
+            call(1, blocked_notification),
+            call(2, during_send),
+            call(3, later_notification),
+        ]
+        assert after_values[0] < 3
+
+    @pytest.mark.asyncio
+    @pytest.mark.parametrize("transport_type", ["tcp", "websocket"])
+    @pytest.mark.parametrize("failing_hook", ["before", "after"])
+    async def test_before_write_or_after_write_failure_cleans_up_request(
+        self,
+        transport_type,
+        failing_hook,
+    ):
+        """Hook errors clear pending state, release the lock, and permit another request."""
+        connection = ICConnection("host", transport=transport_type)
+        writes = []
+
+        if transport_type == "tcp":
+            protocol = ICProtocol(
+                notification_observer_state=connection._notification_observer_state,
+            )
+            transport = MagicMock()
+            protocol.connection_made(transport)
+
+            def write(packet):
+                writes.append(packet)
+                protocol._handle_response(
+                    {
+                        "command": "SendParamList",
+                        "messageID": protocol._pending_message_id,
+                        "response": "200",
+                    }
+                )
+
+            transport.write.side_effect = write
+        else:
+            protocol = ICWebSocketTransport(
+                notification_observer_state=connection._notification_observer_state,
+            )
+            protocol._connected = True
+
+            class RespondingWebSocket:
+                async def send(self, packet):
+                    writes.append(packet)
+                    protocol._handle_response(
+                        {
+                            "command": "SendParamList",
+                            "messageID": protocol._pending_message_id,
+                            "response": "200",
+                        }
+                    )
+
+            protocol._ws = RespondingWebSocket()
+
+        connection._protocol = protocol
+        after_calls = []
+
+        def before_write(_sequence, _started_at):
+            if failing_hook == "before":
+                raise RuntimeError("before hook failed")
+
+        def after_write(sequence):
+            after_calls.append(sequence)
+            if failing_hook == "after":
+                raise RuntimeError("after hook failed")
+
+        loop = asyncio.get_running_loop()
+        unhandled = []
+        previous_handler = loop.get_exception_handler()
+        loop.set_exception_handler(lambda _loop, context: unhandled.append(context))
+        try:
+            with pytest.raises(RuntimeError, match=f"{failing_hook} hook failed"):
+                await connection.send_request(
+                    "GetParamList",
+                    request_timeout=1.0,
+                    _before_write_callback=before_write,
+                    _after_write_callback=after_write,
+                )
+
+            expected_writes = 0 if failing_hook == "before" else 1
+            assert len(writes) == expected_writes
+            assert len(after_calls) == expected_writes
+            assert protocol._pending_message_id is None
+            assert protocol._response_future is None
+            assert not connection._request_lock.locked()
+
+            response = await connection.send_request("GetParamList", request_timeout=1.0)
+            assert response["response"] == "200"
+            assert len(writes) == expected_writes + 1
+            await asyncio.sleep(0)
+        finally:
+            loop.set_exception_handler(previous_handler)
+
+        assert unhandled == []
+
+
+async def _connect_tcp_for_closed_future(connection):
+    """Connect a test connection through its real protocol factory."""
+    loop = asyncio.get_running_loop()
+
+    async def create_connection(protocol_factory, _host, _port):
+        protocol = protocol_factory()
+        transport = MagicMock()
+        protocol.connection_made(transport)
+        return transport, protocol
+
+    with patch.object(loop, "create_connection", side_effect=create_connection):
+        await connection.connect()
+
+    assert isinstance(connection._protocol, ICProtocol)
+    return connection._protocol
+
+
+class TestClosedFutureGenerations:
+    """Tests for one-shot connection-generation close futures."""
+
+    def test_capture_closed_future_rejects_non_live_connection(self):
+        """A caller cannot capture a generation before it is live."""
+        connection = ICConnection("host")
+
+        with pytest.raises(ICConnectionError, match="not live"):
+            connection._capture_closed_future()
+
+    @pytest.mark.asyncio
+    @pytest.mark.parametrize("close_path", ["unexpected", "explicit", "abort"])
+    async def test_closed_future_completes_for_every_close_path(self, close_path):
+        """Unexpected, deliberate, and abort teardown all close the generation."""
+        connection = ICConnection("host", keepalive_interval=3600)
+        protocol = await _connect_tcp_for_closed_future(connection)
+        closed = connection._capture_closed_future()
+        assert not closed.done()
+
+        if close_path == "unexpected":
+            protocol.connection_lost(ConnectionResetError("reset"))
+        elif close_path == "explicit":
+            await connection.disconnect()
+        else:
+            connection._abort_connection(ICConnectionError("dead link"))
+
+        assert closed.done()
+        assert closed.result() is None
+        await connection.disconnect()
+
+    @pytest.mark.asyncio
+    async def test_explicit_disconnect_does_not_dispatch_unexpected_callback(self):
+        """The internal close future is separate from the public failure callback."""
+        connection = ICConnection("host", keepalive_interval=3600)
+        disconnect_callback = MagicMock()
+        connection.set_disconnect_callback(disconnect_callback)
+        loop = asyncio.get_running_loop()
+
+        async def create_connection(protocol_factory, _host, _port):
+            protocol = protocol_factory()
+            transport = MagicMock()
+            protocol.connection_made(transport)
+            transport.close.side_effect = lambda: protocol.connection_lost(None)
+            return transport, protocol
+
+        with patch.object(loop, "create_connection", side_effect=create_connection):
+            await connection.connect()
+
+        closed = connection._capture_closed_future()
+        await connection.disconnect()
+
+        assert closed.done()
+        disconnect_callback.assert_not_called()
+
+    @pytest.mark.asyncio
+    @pytest.mark.parametrize("transport_type", ["tcp", "websocket"])
+    async def test_failed_connect_completes_closed_future(self, transport_type):
+        """Even a connection generation that fails to open has a terminal signal."""
+        connection = ICConnection("host", transport=transport_type)
+
+        if transport_type == "tcp":
+            loop = asyncio.get_running_loop()
+            context = patch.object(
+                loop,
+                "create_connection",
+                side_effect=OSError("connection refused"),
+            )
+        else:
+            context = patch("websockets.connect", side_effect=OSError("connection refused"))
+
+        with context, pytest.raises(ICConnectionError):
+            await connection.connect()
+
+        assert connection._closed_future is not None
+        assert connection._closed_future.done()
+        with pytest.raises(ICConnectionError, match="not live"):
+            connection._capture_closed_future()
+
+    @pytest.mark.asyncio
+    @pytest.mark.parametrize("transport_type", ["tcp", "websocket"])
+    async def test_immediate_disconnect_during_connect_is_failed_generation(self, transport_type):
+        """A transport that closes during setup cannot become a live generation."""
+        disconnects = []
+        connection = ICConnection("host", transport=transport_type)
+        connection.set_disconnect_callback(disconnects.append)
+
+        if transport_type == "tcp":
+            loop = asyncio.get_running_loop()
+
+            async def create_connection(protocol_factory, _host, _port):
+                protocol = protocol_factory()
+                transport = MagicMock()
+                protocol.connection_made(transport)
+                protocol.connection_lost(ConnectionResetError("closed during connect"))
+                return transport, protocol
+
+            context = patch.object(loop, "create_connection", side_effect=create_connection)
+        else:
+
+            async def connect_and_close(transport, _host, _port):
+                transport._ws = MagicMock()
+                transport._connected = True
+                transport._handle_disconnect(ConnectionResetError("closed during connect"))
+
+            context = patch.object(ICWebSocketTransport, "connect", new=connect_and_close)
+
+        error = None
+        try:
+            with context:
+                try:
+                    await connection.connect()
+                except ICConnectionError as err:
+                    error = err
+
+            assert error is not None
+            assert "closed during setup" in str(error)
+            assert not connection.connected
+            assert connection._closed_future is not None
+            assert connection._closed_future.done()
+            assert connection._keepalive_task is None
+            assert len(disconnects) == 1
+            assert isinstance(disconnects[0], ConnectionResetError)
+            assert connection._disconnect_dispatched is True
+        finally:
+            await connection.disconnect()
+
+    @pytest.mark.asyncio
+    async def test_concurrent_connects_cannot_cross_complete_closed_futures(self):
+        """A second attempt waits and cannot steal the first attempt's close signal."""
+        connection = ICConnection("host", keepalive_interval=3600)
+        loop = asyncio.get_running_loop()
+        first_entered = asyncio.Event()
+        release_first = asyncio.Event()
+        second_entered = asyncio.Event()
+        create_calls = 0
+
+        async def create_connection(protocol_factory, _host, _port):
+            nonlocal create_calls
+            create_calls += 1
+            if create_calls == 1:
+                first_entered.set()
+                await release_first.wait()
+                raise OSError("first attempt failed")
+
+            second_entered.set()
+            protocol = protocol_factory()
+            transport = MagicMock()
+            protocol.connection_made(transport)
+            return transport, protocol
+
+        with patch.object(loop, "create_connection", side_effect=create_connection):
+            first_task = asyncio.create_task(connection.connect())
+            await first_entered.wait()
+            first_closed = connection._closed_future
+            assert first_closed is not None
+
+            second_task = asyncio.create_task(connection.connect())
+            await asyncio.sleep(0)
+            second_started_before_release = second_entered.is_set()
+            release_first.set()
+            first_result, second_result = await asyncio.gather(
+                first_task,
+                second_task,
+                return_exceptions=True,
+            )
+
+        try:
+            assert not second_started_before_release
+            assert isinstance(first_result, ICConnectionError)
+            assert second_result is None
+            assert first_closed.done()
+            second_closed = connection._capture_closed_future()
+            assert second_closed is not first_closed
+            assert not second_closed.done()
+            assert connection.connected
+        finally:
+            await connection.disconnect()
+
+    @pytest.mark.asyncio
+    async def test_closed_future_is_distinct_across_same_instance_reconnect(self):
+        """A reconnect cannot clear a previously captured close signal."""
+        connection = ICConnection("host", keepalive_interval=3600)
+        disconnect_callback = MagicMock()
+        connection.set_disconnect_callback(disconnect_callback)
+        loop = asyncio.get_running_loop()
+        protocols = []
+
+        async def create_connection(protocol_factory, _host, _port):
+            protocol = protocol_factory()
+            transport = MagicMock()
+            protocol.connection_made(transport)
+            protocols.append(protocol)
+            return transport, protocol
+
+        with patch.object(loop, "create_connection", side_effect=create_connection):
+            await connection.connect()
+            first_closed = connection._capture_closed_future()
+            protocols[0].connection_lost(ConnectionResetError("first generation closed"))
+            assert first_closed.done()
+            disconnect_callback.assert_called_once()
+
+            await connection.connect()
+            second_closed = connection._capture_closed_future()
+
+            protocols[0].connection_lost(ConnectionResetError("late old disconnect"))
+
+        assert second_closed is not first_closed
+        assert not second_closed.done()
+        assert first_closed.done()
+        disconnect_callback.assert_called_once()
+        assert protocols[0]._notification_observer_state is connection._notification_observer_state
+        assert protocols[1]._notification_observer_state is connection._notification_observer_state
+
+        await connection.disconnect()
+        assert second_closed.done()

--- a/tests/test_controller.py
+++ b/tests/test_controller.py
@@ -1336,15 +1336,20 @@ class TestICModelController:
         assert controller._system_info.prop_name == "New Pool"
 
     def test_get_circuit_groups(self, controller, model):
-        """Test get_circuit_groups returns all circuit group objects."""
-        model.add_object("CG001", {"OBJTYP": "CIRCGRP", "SNAME": "Light Group 1"})
-        model.add_object("CG002", {"OBJTYP": "CIRCGRP", "SNAME": "Light Group 2"})
+        """Test get_circuit_groups returns parent circuits, not member rows."""
+        model.add_object(
+            "CG001", {"OBJTYP": "CIRCUIT", "SUBTYP": "LITSHO", "SNAME": "Light Group 1"}
+        )
+        model.add_object(
+            "CG002", {"OBJTYP": "CIRCUIT", "SUBTYP": "CIRCGRP", "SNAME": "Light Group 2"}
+        )
+        model.add_object("ROW001", {"OBJTYP": "CIRCGRP", "PARENT": "CG001", "CIRCUIT": "C001"})
         model.add_object("C001", {"OBJTYP": "CIRCUIT", "SUBTYP": "INTELLI", "SNAME": "Light"})
 
         groups = controller.get_circuit_groups()
 
         assert len(groups) == 2
-        assert all(obj.objtype == "CIRCGRP" for obj in groups)
+        assert all(obj.objtype == "CIRCUIT" for obj in groups)
 
     def test_get_circuits_in_group(self, controller, model):
         """Test get_circuits_in_group returns circuits belonging to a group."""
@@ -1422,16 +1427,18 @@ class TestICModelController:
         # Create circuits
         model.add_object("C001", {"OBJTYP": "CIRCUIT", "SUBTYP": "INTELLI", "SNAME": "Pool Light"})
         model.add_object("C002", {"OBJTYP": "CIRCUIT", "SUBTYP": "LIGHT", "SNAME": "Deck Light"})
-        # Create circuit groups
+        # Create circuit-group parents and membership rows
         model.add_object(
             "CG001",
-            {"OBJTYP": "CIRCGRP", "SNAME": "Color Group", "CIRCUIT": "C001"},
+            {"OBJTYP": "CIRCUIT", "SUBTYP": "LITSHO", "SNAME": "Color Group"},
         )
         model.add_object(
             "CG002",
-            {"OBJTYP": "CIRCGRP", "SNAME": "Non-Color Group", "CIRCUIT": "C002"},
+            {"OBJTYP": "CIRCUIT", "SUBTYP": "LITSHO", "SNAME": "Non-Color Group"},
         )
-        model.add_object("CG003", {"OBJTYP": "CIRCGRP", "SNAME": "Empty Group"})
+        model.add_object("CG003", {"OBJTYP": "CIRCUIT", "SUBTYP": "LITSHO", "SNAME": "Empty Group"})
+        model.add_object("ROW001", {"OBJTYP": "CIRCGRP", "PARENT": "CG001", "CIRCUIT": "C001"})
+        model.add_object("ROW002", {"OBJTYP": "CIRCGRP", "PARENT": "CG002", "CIRCUIT": "C002"})
 
         color_groups = controller.get_color_light_groups()
 
@@ -1442,11 +1449,12 @@ class TestICModelController:
         """Test get_all_entities includes circuit_groups and color_light_groups."""
         # Create color light
         model.add_object("C001", {"OBJTYP": "CIRCUIT", "SUBTYP": "INTELLI", "SNAME": "Pool Light"})
-        # Create circuit group with color light
+        # Create circuit-group parent with a color-light membership row
         model.add_object(
             "CG001",
-            {"OBJTYP": "CIRCGRP", "SNAME": "Color Group", "CIRCUIT": "C001"},
+            {"OBJTYP": "CIRCUIT", "SUBTYP": "LITSHO", "SNAME": "Color Group"},
         )
+        model.add_object("ROW001", {"OBJTYP": "CIRCGRP", "PARENT": "CG001", "CIRCUIT": "C001"})
 
         entities = controller.get_all_entities()
 

--- a/tests/test_controller.py
+++ b/tests/test_controller.py
@@ -1523,6 +1523,282 @@ class TestICModelController:
         assert controller.get_light_effect_name("C001") == "SAm"
 
 
+class TestMutationLifecycle:
+    """Test exclusive controller mutation lifecycle behavior."""
+
+    @pytest.fixture
+    def controller(self):
+        """Create a connected controller with a deterministic transport fake."""
+        ctrl = ICModelController("192.168.1.100", PoolModel(), 6681)
+        ctrl._connection = MagicMock()
+        ctrl._connection.connected = True
+        ctrl._connection.send_request = AsyncMock(return_value={"response": "200"})
+        return ctrl
+
+    @pytest.mark.asyncio
+    async def test_sync_pending_rejects_all_writer_spellings_but_allows_reads(self, controller):
+        """Later object writers fail fast while read-only requests stay live."""
+        async with controller._light_group_mutation_lifecycle():
+            for command in (
+                "SETPARAMLIST",
+                "SetParamList",
+                "setparamlist",
+                "sEtPaRaMlIsT",
+            ):
+                with pytest.raises(ICError, match="Color Sync mutation lifecycle"):
+                    await controller.send_cmd(command, {"objectList": []})
+
+            with pytest.raises(ICError, match="Color Sync mutation lifecycle"):
+                await controller.request_changes("C001", {"STATUS": "ON"})
+
+            with pytest.raises(ICError, match="Color Sync mutation lifecycle"):
+                async with controller._light_group_mutation_lifecycle():
+                    pytest.fail("a second Sync must never acquire the lifecycle")
+
+            assert await controller.send_cmd("GetParamList") == {"response": "200"}
+
+        controller._connection.send_request.assert_awaited_once_with("GetParamList")
+
+    @pytest.mark.asyncio
+    async def test_sync_marks_pending_before_draining_an_already_started_writer(self, controller):
+        """A writer owning the lifecycle drains, while a later writer is rejected."""
+        writer_started = asyncio.Event()
+        release_writer = asyncio.Event()
+        sync_owned = asyncio.Event()
+
+        async def slow_send(*args, **kwargs):
+            writer_started.set()
+            await release_writer.wait()
+            return {"response": "200"}
+
+        controller._connection.send_request = slow_send
+        first_writer = asyncio.create_task(controller.send_cmd("SetParamList", {"objectList": []}))
+        await writer_started.wait()
+
+        async def own_sync_lifecycle():
+            async with controller._light_group_mutation_lifecycle():
+                sync_owned.set()
+
+        sync_task = asyncio.create_task(own_sync_lifecycle())
+        await asyncio.sleep(0)
+        assert controller._light_group_mutation_pending is True
+        assert sync_owned.is_set() is False
+
+        with pytest.raises(ICError, match="Color Sync mutation lifecycle"):
+            await controller.send_cmd("SETPARAMLIST", {"objectList": []})
+
+        release_writer.set()
+        await first_writer
+        await sync_task
+        assert sync_owned.is_set() is True
+        assert controller._light_group_mutation_pending is False
+
+    @pytest.mark.asyncio
+    async def test_sync_wait_cancellation_clears_pending(self, controller):
+        """Cancellation while waiting for an older writer restores admission."""
+
+        async def wait_for_sync_lifecycle():
+            async with controller._light_group_mutation_lifecycle():
+                pytest.fail("cancelled waiter must not acquire the lifecycle")
+
+        async with controller._mutation_lifecycle():
+            waiter = asyncio.create_task(wait_for_sync_lifecycle())
+            await asyncio.sleep(0)
+            assert controller._light_group_mutation_pending is True
+            waiter.cancel()
+            with pytest.raises(asyncio.CancelledError):
+                await waiter
+            assert controller._light_group_mutation_pending is False
+
+    @pytest.mark.asyncio
+    async def test_sync_owner_cancellation_releases_every_lifecycle_field(self, controller):
+        """Cancellation after ownership invalidates the lease before unlock."""
+        owned = asyncio.Event()
+
+        async def hold_sync_lifecycle():
+            async with controller._light_group_mutation_lifecycle():
+                owned.set()
+                await asyncio.Event().wait()
+
+        task = asyncio.create_task(hold_sync_lifecycle())
+        await owned.wait()
+        assert controller._mutation_lock.locked() is True
+        assert controller._mutation_owner is task
+        assert controller._light_group_mutation_lease is not None
+
+        task.cancel()
+        with pytest.raises(asyncio.CancelledError):
+            await task
+
+        assert controller._mutation_lock.locked() is False
+        assert controller._mutation_owner is None
+        assert controller._light_group_mutation_lease is None
+        assert controller._light_group_mutation_pending is False
+
+    @pytest.mark.asyncio
+    async def test_exact_lease_authorizes_one_delegated_request(self, controller):
+        """Only the current opaque lease can use the captured-connection primitive."""
+        connection = controller._connection
+        before = MagicMock()
+        after = MagicMock()
+
+        async with controller._light_group_mutation_lifecycle() as lease:
+            result = await asyncio.create_task(
+                controller._send_cmd_on_connection_unlocked(
+                    connection,
+                    "SetParamList",
+                    {"objectList": []},
+                    _mutation_lease=lease,
+                    request_timeout=60.0,
+                    _before_write_callback=before,
+                    _after_write_callback=after,
+                )
+            )
+            assert result == {"response": "200"}
+
+            with pytest.raises(ICError, match="lease"):
+                await controller._send_cmd_on_connection_unlocked(
+                    connection,
+                    "SetParamList",
+                    _mutation_lease=object(),
+                )
+
+        with pytest.raises(ICError, match="lease"):
+            await controller._send_cmd_on_connection_unlocked(
+                connection,
+                "SetParamList",
+                _mutation_lease=lease,
+            )
+
+        connection.send_request.assert_awaited_once_with(
+            "SetParamList",
+            request_timeout=60.0,
+            _before_write_callback=before,
+            _after_write_callback=after,
+            objectList=[],
+        )
+
+    @pytest.mark.asyncio
+    async def test_unlocked_request_rejects_replaced_connection(self, controller):
+        """The private primitive never falls through to a replacement connection."""
+        old_connection = controller._connection
+
+        async with controller._light_group_mutation_lifecycle() as lease:
+            replacement = MagicMock()
+            replacement.connected = True
+            replacement.send_request = AsyncMock(return_value={"response": "200"})
+            controller._connection = replacement
+
+            with pytest.raises(ICConnectionError, match="changed"):
+                await controller._send_cmd_on_connection_unlocked(
+                    old_connection,
+                    "GetParamList",
+                    _mutation_lease=lease,
+                )
+
+        old_connection.send_request.assert_not_awaited()
+        replacement.send_request.assert_not_awaited()
+
+    @pytest.mark.asyncio
+    async def test_queue_helpers_fail_before_touching_coalescing_state(self, controller):
+        """Busy checks run synchronously before either coalescing helper queues."""
+        await controller._coalesce_lock.acquire()
+        controller._light_group_mutation_pending = True
+        try:
+            with pytest.raises(ICError, match="Color Sync mutation lifecycle"):
+                await controller._queue_property_change("C001", {"STATUS": "ON"})
+            with pytest.raises(ICError, match="Color Sync mutation lifecycle"):
+                await controller._queue_batch_changes({"C002": {"STATUS": "ON"}})
+            assert controller._pending_changes == {}
+            assert controller._pending_requests == []
+        finally:
+            controller._light_group_mutation_pending = False
+            controller._coalesce_lock.release()
+
+    @pytest.mark.asyncio
+    async def test_busy_flush_completes_every_detached_waiter(self, controller):
+        """A busy ICError is fanned out without orphaning coalesced futures."""
+        await controller._coalesce_lock.acquire()
+        first = asyncio.create_task(controller.set_circuit_state("C001", True))
+        second = asyncio.create_task(controller.set_circuit_state("C002", True))
+        await asyncio.sleep(0)
+        controller._light_group_mutation_pending = True
+        controller._coalesce_lock.release()
+
+        results = await asyncio.gather(first, second, return_exceptions=True)
+        assert all(isinstance(result, ICError) for result in results)
+        assert results[0] is results[1]
+        assert controller._pending_changes == {}
+        assert controller._pending_requests == []
+        controller._connection.send_request.assert_not_awaited()
+        controller._light_group_mutation_pending = False
+
+    @pytest.mark.asyncio
+    async def test_pre_detach_cancellation_rebuilds_latest_wins_batch(self, controller):
+        """Removing a queued override restores the surviving admitted value."""
+        await controller._coalesce_lock.acquire()
+        first = asyncio.create_task(controller.set_circuit_state("C001", True))
+        await asyncio.sleep(0)
+        cancelled = asyncio.create_task(controller.set_circuit_state("C001", False))
+        await asyncio.sleep(0)
+
+        cancelled.cancel()
+        with pytest.raises(asyncio.CancelledError):
+            await cancelled
+        assert controller._pending_changes == {"C001": {"STATUS": "ON"}}
+        assert len(controller._pending_requests) == 1
+
+        controller._coalesce_lock.release()
+        await first
+        sent = controller._connection.send_request.await_args.kwargs["objectList"]
+        assert sent == [{"objnam": "C001", "params": {"STATUS": "ON"}}]
+
+    @pytest.mark.asyncio
+    async def test_pre_detach_cancellation_removes_distinct_object(self, controller):
+        """A cancelled distinct-object request cannot leak into a later batch."""
+        await controller._coalesce_lock.acquire()
+        survivor = asyncio.create_task(controller.set_circuit_state("C001", True))
+        await asyncio.sleep(0)
+        cancelled = asyncio.create_task(controller.set_circuit_state("C002", True))
+        await asyncio.sleep(0)
+
+        cancelled.cancel()
+        with pytest.raises(asyncio.CancelledError):
+            await cancelled
+        assert controller._pending_changes == {"C001": {"STATUS": "ON"}}
+
+        controller._coalesce_lock.release()
+        await survivor
+        sent = controller._connection.send_request.await_args.kwargs["objectList"]
+        assert sent == [{"objnam": "C001", "params": {"STATUS": "ON"}}]
+
+    @pytest.mark.asyncio
+    async def test_detached_flush_owner_cancellation_marks_peers_uncertain(self, controller):
+        """A possibly dispatched batch is never requeued after owner cancellation."""
+        send_started = asyncio.Event()
+
+        async def suspended_send(*args, **kwargs):
+            send_started.set()
+            await asyncio.Event().wait()
+
+        controller._connection.send_request = suspended_send
+        await controller._coalesce_lock.acquire()
+        owner = asyncio.create_task(controller.set_circuit_state("C001", True))
+        peer = asyncio.create_task(controller.set_circuit_state("C002", True))
+        await asyncio.sleep(0)
+        controller._coalesce_lock.release()
+        await send_started.wait()
+
+        owner.cancel()
+        with pytest.raises(asyncio.CancelledError):
+            await owner
+        with pytest.raises(ICError, match="delivery is unknown"):
+            await peer
+
+        assert controller._pending_changes == {}
+        assert controller._pending_requests == []
+
+
 class TestRequestCoalescing:
     """Test request coalescing behavior in ICModelController."""
 

--- a/tests/test_controller.py
+++ b/tests/test_controller.py
@@ -1841,6 +1841,27 @@ class TestMutationLifecycle:
         assert await later_caller == {"response": "200"}
         assert call_count == 2
 
+    @pytest.mark.asyncio
+    async def test_cancelled_detached_caller_consumes_completed_exception(self, controller):
+        """Caller cancellation retrieves an already-completed detached failure."""
+        await controller._coalesce_lock.acquire()
+        caller = asyncio.create_task(controller.set_circuit_state("C001", True))
+        await asyncio.sleep(0)
+        request = controller._pending_requests[0]
+
+        # Model the atomic state immediately after another flush detached this
+        # caller, then completed its future before the lock waiter resumed.
+        controller._pending_requests = []
+        controller._pending_changes = {}
+        request.future.set_exception(ICError("detached batch failed"))
+
+        caller.cancel()
+        with pytest.raises(asyncio.CancelledError):
+            await caller
+        assert request.future.done() is True
+        assert request.future._log_traceback is False
+        controller._coalesce_lock.release()
+
 
 class TestRequestCoalescing:
     """Test request coalescing behavior in ICModelController."""

--- a/tests/test_controller.py
+++ b/tests/test_controller.py
@@ -1798,6 +1798,49 @@ class TestMutationLifecycle:
         assert controller._pending_changes == {}
         assert controller._pending_requests == []
 
+    @pytest.mark.asyncio
+    async def test_completed_peer_never_flushes_a_later_callers_batch(self, controller):
+        """A request detached by an earlier flush cannot own unrelated work."""
+        first_send_started = asyncio.Event()
+        release_first_send = asyncio.Event()
+        second_send_started = asyncio.Event()
+        release_second_send = asyncio.Event()
+        call_count = 0
+
+        async def scripted_send(*args, **kwargs):
+            nonlocal call_count
+            call_count += 1
+            if call_count == 1:
+                first_send_started.set()
+                await release_first_send.wait()
+                raise ICConnectionError("first batch failed")
+            second_send_started.set()
+            await release_second_send.wait()
+            return {"response": "200"}
+
+        controller._connection.send_request = scripted_send
+        await controller._coalesce_lock.acquire()
+        first_owner = asyncio.create_task(controller.set_circuit_state("C001", True))
+        completed_peer = asyncio.create_task(controller.set_circuit_state("C002", True))
+        await asyncio.sleep(0)
+        controller._coalesce_lock.release()
+        await first_send_started.wait()
+
+        later_caller = asyncio.create_task(controller.set_circuit_state("C003", True))
+        await asyncio.sleep(0)
+        release_first_send.set()
+
+        with pytest.raises(ICConnectionError, match="first batch failed"):
+            await first_owner
+        await second_send_started.wait()
+        assert completed_peer.done() is True
+        with pytest.raises(ICConnectionError, match="first batch failed"):
+            await completed_peer
+
+        release_second_send.set()
+        assert await later_caller == {"response": "200"}
+        assert call_count == 2
+
 
 class TestRequestCoalescing:
     """Test request coalescing behavior in ICModelController."""

--- a/tests/test_light_group_sync.py
+++ b/tests/test_light_group_sync.py
@@ -1,0 +1,2278 @@
+"""Tests for the evidence-bounded light-group Color Sync lifecycle."""
+
+from __future__ import annotations
+
+import asyncio
+import contextlib
+import copy
+from dataclasses import dataclass
+from typing import Any
+
+import pytest
+
+import pyintellicenter._light_group as light_group
+from pyintellicenter import (
+    ICCommandError,
+    ICConnectionError,
+    ICError,
+    ICLightGroupError,
+    ICModelController,
+    ICSystemInfo,
+    PoolModel,
+)
+
+PROJECTION_KEYS = (
+    "OBJTYP",
+    "SUBTYP",
+    "PARENT",
+    "CIRCUIT",
+    "LISTORD",
+    "STATUS",
+    "USE",
+    "SYNC",
+    "SET",
+    "SWIM",
+    "VER",
+    "SERVICE",
+)
+
+
+@dataclass(frozen=True)
+class RecordedCall:
+    """One scripted connection request."""
+
+    command: str
+    kwargs: dict[str, Any]
+    request_timeout: float | None
+
+
+class ScriptedConnection:
+    """Deterministic connection fake with explicit transport boundaries."""
+
+    def __init__(
+        self,
+        projections: list[dict[str, Any]],
+        *,
+        action_frames: list[dict[str, Any]],
+    ) -> None:
+        self.connected = True
+        self.calls: list[RecordedCall] = []
+        self.observers: list[Any] = []
+        self.projections = projections
+        self.action_frames = action_frames
+        self.action_response: dict[str, Any] = {
+            "messageID": "4",
+            "response": "200",
+            "opaqueVendorField": {"kept": True},
+        }
+        self._sequence = 0
+        self._get_index = 0
+        self._message_id = 0
+        self._command_counts: dict[str, int] = {}
+        self.closed = asyncio.get_running_loop().create_future()
+        self.capture_count = 0
+        self.remove_count = 0
+        self.before_response_frames: dict[tuple[str, int], list[dict[str, Any]]] = {}
+        self.before_write_frames: list[dict[str, Any]] = []
+        self.between_write_frames: list[dict[str, Any]] = []
+        self.action_gate: asyncio.Event | None = None
+        self.action_response_gate: asyncio.Event | None = None
+        self.action_error: BaseException | None = None
+        self.scripts: dict[tuple[str, int], Any] = {}
+
+    def _capture_closed_future(self) -> asyncio.Future[None]:
+        self.capture_count += 1
+        return self.closed
+
+    def add_notification_observer(self, observer: Any) -> Any:
+        self.observers.append(observer)
+        removed = False
+
+        def remove() -> None:
+            nonlocal removed
+            if removed:
+                return
+            removed = True
+            self.remove_count += 1
+            self.observers.remove(observer)
+
+        return remove
+
+    def emit(self, frame: dict[str, Any]) -> None:
+        self._sequence += 1
+        for observer in tuple(self.observers):
+            observer(self._sequence, frame)
+
+    def close_generation(self) -> None:
+        if not self.closed.done():
+            self.closed.set_result(None)
+
+    def reconnect_same_instance(self) -> asyncio.Future[None]:
+        old = self.closed
+        self.close_generation()
+        self.closed = asyncio.get_running_loop().create_future()
+        self.connected = True
+        return old
+
+    def _emit_before_response(self, command: str, occurrence: int) -> None:
+        for frame in self.before_response_frames.get((command, occurrence), []):
+            self.emit(frame)
+
+    def _subscription_response(self, request: list[dict[str, Any]]) -> dict[str, Any]:
+        raw_entries = {
+            entry["objnam"]: entry["params"] for entry in self.projections[0]["objectList"]
+        }
+        object_list = []
+        for item in request:
+            params = raw_entries[item["objnam"]]
+            object_list.append(
+                {
+                    "objnam": item["objnam"],
+                    "params": {key: params[key] for key in item["keys"] if key in params},
+                }
+            )
+        return {
+            "messageID": str(self._message_id),
+            "response": "200",
+            "objectList": object_list,
+        }
+
+    async def send_request(
+        self,
+        command: str,
+        request_timeout: float | None = None,
+        *,
+        _before_write_callback: Any = None,
+        _after_write_callback: Any = None,
+        **kwargs: Any,
+    ) -> dict[str, Any]:
+        self.calls.append(RecordedCall(command, kwargs, request_timeout))
+        self._message_id += 1
+        occurrence = self._command_counts.get(command, 0) + 1
+        self._command_counts[command] = occurrence
+
+        script = self.scripts.get((command, occurrence))
+        if script is not None:
+            return await script(
+                self,
+                _before_write_callback,
+                _after_write_callback,
+                kwargs,
+            )
+
+        if command != "SetParamList":
+            if _before_write_callback is not None:
+                _before_write_callback(self._sequence, asyncio.get_running_loop().time())
+            if _after_write_callback is not None:
+                _after_write_callback(self._sequence)
+
+        if command == "GetParamList":
+            response = self.projections[self._get_index]
+            self._get_index += 1
+            self._emit_before_response(command, occurrence)
+            return {
+                "messageID": str(self._message_id),
+                "response": "200",
+                **response,
+            }
+        if command == "RequestParamList":
+            self._emit_before_response(command, occurrence)
+            return self._subscription_response(kwargs["objectList"])
+        if command == "SetParamList":
+            for frame in self.before_write_frames:
+                self.emit(frame)
+            if _before_write_callback is not None:
+                _before_write_callback(self._sequence, asyncio.get_running_loop().time())
+            for frame in self.between_write_frames:
+                self.emit(frame)
+            if self.action_gate is not None:
+                await self.action_gate.wait()
+            if _after_write_callback is not None:
+                _after_write_callback(self._sequence)
+            for frame in self.action_frames:
+                self.emit(frame)
+            if self.action_response_gate is not None:
+                await self.action_response_gate.wait()
+            if self.action_error is not None:
+                raise self.action_error
+            self._emit_before_response(command, occurrence)
+            return self.action_response
+        self._emit_before_response(command, occurrence)
+        return {"messageID": str(self._message_id), "response": "200"}
+
+
+def _entry(objnam: str, **params: str) -> dict[str, Any]:
+    return {"objnam": objnam, "params": params}
+
+
+def make_projection(status: str) -> dict[str, Any]:
+    """Build one complete hardware-shaped wildcard projection."""
+    return {
+        "objectList": [
+            _entry("SYS", OBJTYP="SYSTEM", VER="1.064", SERVICE="AUTO"),
+            _entry(
+                "GROUP",
+                OBJTYP="CIRCUIT",
+                SUBTYP="LITSHO",
+                PARENT="PARENT",
+                STATUS=status,
+                USE="USE",
+                SYNC="OFF",
+                SET="OFF",
+                SWIM="OFF",
+            ),
+            _entry(
+                "CHILD_A",
+                OBJTYP="CIRCUIT",
+                SUBTYP="GLOW",
+                PARENT="GROUP",
+                STATUS=status,
+                USE="USE",
+            ),
+            _entry(
+                "CHILD_B",
+                OBJTYP="CIRCUIT",
+                SUBTYP="GLOW",
+                PARENT="GROUP",
+                STATUS=status,
+                USE="USE",
+            ),
+            _entry("AUX", OBJTYP="CIRCUIT", SUBTYP="LIGHT", STATUS="OFF"),
+            _entry(
+                "OTHER_GROUP",
+                OBJTYP="CIRCUIT",
+                SUBTYP="LITSHO",
+                STATUS="OFF",
+                SYNC="OFF",
+                SET="OFF",
+                SWIM="OFF",
+            ),
+            _entry(
+                "ROW_A",
+                OBJTYP="CIRCGRP",
+                PARENT="GROUP",
+                CIRCUIT="CHILD_A",
+                LISTORD="1",
+            ),
+            _entry(
+                "ROW_B",
+                OBJTYP="CIRCGRP",
+                PARENT="GROUP",
+                CIRCUIT="CHILD_B",
+                LISTORD="2",
+                USE="00000",
+            ),
+            _entry(
+                "OTHER_ROW",
+                OBJTYP="CIRCGRP",
+                PARENT="OTHER_GROUP",
+                CIRCUIT="AUX",
+                LISTORD="1",
+                USE="USE",
+            ),
+            _entry("IGNORED", OBJTYP="MODULE", STATUS="STATUS"),
+        ]
+    }
+
+
+def final_projection(status: str) -> dict[str, Any]:
+    projection = make_projection(status)
+    for entry in projection["objectList"]:
+        if entry["objnam"] in {"GROUP", "CHILD_A", "CHILD_B"}:
+            entry["params"]["STATUS"] = "ON"
+    return projection
+
+
+def action_frames(status: str) -> list[dict[str, Any]]:
+    frames: list[dict[str, Any]] = []
+    if status == "OFF":
+        frames.extend(
+            [
+                {"command": "NotifyList", "objectList": [_entry("CHILD_B", STATUS="ON")]},
+                {"command": "NotifyList", "objectList": [_entry("GROUP", STATUS="ON")]},
+                {"command": "NotifyList", "objectList": [_entry("CHILD_A", STATUS="ON")]},
+            ]
+        )
+    frames.extend(
+        [
+            {"command": "NotifyList", "objectList": [_entry("GROUP", SYNC="ON")]},
+            {"command": "NotifyList", "objectList": [_entry("GROUP", SYNC="OFF")]},
+        ]
+    )
+    return frames
+
+
+def make_controller(
+    status: str = "OFF",
+    *,
+    firmware: str = "1.064",
+    settled: dict[str, Any] | None = None,
+    frames: list[dict[str, Any]] | None = None,
+) -> tuple[ICModelController, ScriptedConnection]:
+    controller = make_cached_controller(status, firmware=firmware)
+    connection = ScriptedConnection(
+        [make_projection(status), settled or make_projection(status), final_projection(status)],
+        action_frames=frames if frames is not None else action_frames(status),
+    )
+    controller._connection = connection  # type: ignore[assignment]
+    return controller, connection
+
+
+def make_cached_controller(
+    status: str = "OFF",
+    *,
+    firmware: str = "1.064",
+) -> ICModelController:
+    return make_cached_controller_from_projection(make_projection(status), firmware=firmware)
+
+
+def make_cached_controller_from_projection(
+    cached: dict[str, Any],
+    *,
+    firmware: str = "1.064",
+) -> ICModelController:
+    model = PoolModel()
+    for entry in cached["objectList"]:
+        model.add_object(entry["objnam"], dict(entry["params"]))
+
+    controller = ICModelController("192.0.2.1", model)
+    controller._system_info = ICSystemInfo(
+        "SYS",
+        {
+            "PROPNAME": "Pool",
+            "VER": firmware,
+            "MODE": "ENGLISH",
+            "SNAME": "Pool",
+        },
+    )
+    return controller
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("transport", ["tcp", "websocket"])
+@pytest.mark.parametrize("status", ["OFF", "ON"])
+async def test_run_light_group_sync_happy_path(
+    monkeypatch: pytest.MonkeyPatch,
+    transport: str,
+    status: str,
+) -> None:
+    controller, connection = make_controller(status)
+    controller._transport = transport  # transport parity is exercised by the scripted boundaries
+    monkeypatch.setattr(light_group, "SUBSCRIPTION_SETTLE_SECONDS", 0)
+    monkeypatch.setattr(light_group, "SYNC_POST_TERMINAL_OBSERVATION_SECONDS", 0)
+
+    ack = await controller.run_light_group_sync("GROUP")
+
+    assert ack is connection.action_response
+    assert [call.command for call in connection.calls] == [
+        "GetParamList",
+        "RequestParamList",
+        "GetParamList",
+        "SetParamList",
+        "GetParamList",
+    ]
+    assert connection.calls[3].kwargs == {
+        "objectList": [{"objnam": "GROUP", "params": {"SYNC": "ON"}}]
+    }
+    assert connection.calls[3].request_timeout == 60.0
+    for call in (connection.calls[0], connection.calls[2], connection.calls[4]):
+        assert call.kwargs == {
+            "condition": "",
+            "objectList": [{"objnam": "INCR", "keys": list(PROJECTION_KEYS)}],
+        }
+    subscription = connection.calls[1].kwargs["objectList"]
+    assert sum(len(item["keys"]) for item in subscription) <= 50
+    assert connection.observers == []
+    assert controller._light_group_mutation_pending is False
+    assert controller._light_group_mutation_lease is None
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("firmware", ["", "IC: 1.064", "1.064 ", "1.064-build", "3.008"])
+async def test_cached_firmware_gate_rejects_before_io(firmware: str) -> None:
+    controller, connection = make_controller(firmware=firmware)
+
+    with pytest.raises(ValueError, match="firmware"):
+        await controller.run_light_group_sync("GROUP")
+
+    assert connection.calls == []
+
+
+@pytest.mark.asyncio
+async def test_second_projection_mismatch_is_ordinary_pre_dispatch_error(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    settled = make_projection("OFF")
+    next(entry for entry in settled["objectList"] if entry["objnam"] == "AUX")["params"][
+        "STATUS"
+    ] = "ON"
+    controller, connection = make_controller(settled=settled)
+    monkeypatch.setattr(light_group, "SUBSCRIPTION_SETTLE_SECONDS", 0)
+
+    with pytest.raises(ICError, match="preflight mismatch") as raised:
+        await controller.run_light_group_sync("GROUP")
+
+    assert not isinstance(raised.value, ICLightGroupError)
+    assert all(call.command != "SetParamList" for call in connection.calls)
+    assert connection.observers == []
+
+
+def test_light_group_error_metadata_is_read_only_and_safe() -> None:
+    error = ICLightGroupError(
+        "failed",
+        phase="terminal",
+        response_received=True,
+        acknowledged=True,
+        onset_seen=True,
+    )
+
+    assert error.phase == "terminal"
+    assert error.dispatch_started is True
+    assert error.response_received is True
+    assert error.acknowledged is True
+    assert error.onset_seen is True
+    assert "terminal" in repr(error)
+    assert "failed" not in repr(error)
+    with pytest.raises(AttributeError):
+        error.phase = "onset"  # type: ignore[misc]
+
+
+def test_only_scoped_sync_api_exists() -> None:
+    assert hasattr(ICModelController, "run_light_group_sync")
+    assert not hasattr(ICModelController, "run_light_group_command")
+    assert not hasattr(ICModelController, "run_light_group_swim")
+    assert not hasattr(ICModelController, "set_light_group_member_position")
+
+
+def _tracker(status: str = "OFF") -> light_group.LightGroupSyncTracker:
+    controller = make_cached_controller(status)
+    topology = light_group.build_topology(controller, "GROUP")
+    tracker = light_group.LightGroupSyncTracker(topology)
+    tracker.set_prewrite_baseline(light_group.parse_projection(make_projection(status), topology))
+    return tracker
+
+
+def _subscription_response(
+    request: list[dict[str, Any]],
+    projection: dict[str, Any] | None = None,
+) -> dict[str, Any]:
+    raw_entries = {
+        entry["objnam"]: entry["params"]
+        for entry in (projection or make_projection("OFF"))["objectList"]
+    }
+    return {
+        "messageID": "2",
+        "response": "200",
+        "objectList": [
+            {
+                "objnam": item["objnam"],
+                "params": {
+                    key: raw_entries[item["objnam"]][key]
+                    for key in item["keys"]
+                    if key in raw_entries[item["objnam"]]
+                },
+            }
+            for item in request
+        ],
+    }
+
+
+@pytest.mark.parametrize(
+    "case",
+    [
+        "missing_target",
+        "target_is_row",
+        "ordinary_target",
+        "zero_rows",
+        "one_row",
+        "three_rows",
+        "duplicate_child_reference",
+        "missing_child",
+        "wrong_child_type",
+        "wrong_child_subtype",
+        "listord_null",
+        "listord_placeholder",
+        "listord_nonnumeric",
+        "listord_negative",
+    ],
+)
+def test_cached_topology_rejects_every_unsupported_shape(case: str) -> None:
+    cached = make_projection("OFF")
+    target = "GROUP"
+    entries = cached["objectList"]
+    by_name = {entry["objnam"]: entry for entry in entries}
+    if case == "missing_target":
+        cached["objectList"] = [entry for entry in entries if entry["objnam"] != "GROUP"]
+    elif case == "target_is_row":
+        target = "ROW_A"
+    elif case == "ordinary_target":
+        by_name["GROUP"]["params"]["SUBTYP"] = "LIGHT"
+    elif case == "zero_rows":
+        cached["objectList"] = [
+            entry for entry in entries if entry["objnam"] not in {"ROW_A", "ROW_B"}
+        ]
+    elif case == "one_row":
+        cached["objectList"] = [entry for entry in entries if entry["objnam"] != "ROW_B"]
+    elif case == "three_rows":
+        cached["objectList"].append(
+            _entry(
+                "ROW_C",
+                OBJTYP="CIRCGRP",
+                PARENT="GROUP",
+                CIRCUIT="AUX",
+                LISTORD="3",
+            )
+        )
+    elif case == "duplicate_child_reference":
+        by_name["ROW_B"]["params"]["CIRCUIT"] = "CHILD_A"
+    elif case == "missing_child":
+        by_name["ROW_B"]["params"]["CIRCUIT"] = "MISSING"
+    elif case == "wrong_child_type":
+        by_name["CHILD_B"]["params"]["OBJTYP"] = "MODULE"
+    elif case == "wrong_child_subtype":
+        by_name["CHILD_B"]["params"]["SUBTYP"] = "INTELLI"
+    elif case == "listord_null":
+        by_name["ROW_A"]["params"]["LISTORD"] = "00000"
+    elif case == "listord_placeholder":
+        by_name["ROW_A"]["params"]["LISTORD"] = "LISTORD"
+    elif case == "listord_nonnumeric":
+        by_name["ROW_A"]["params"]["LISTORD"] = "first"
+    elif case == "listord_negative":
+        by_name["ROW_A"]["params"]["LISTORD"] = "-1"
+
+    controller = make_cached_controller_from_projection(cached)
+
+    with pytest.raises(ValueError):
+        light_group.build_topology(controller, target)
+
+
+def test_cached_topology_requires_cached_system_info() -> None:
+    controller = make_cached_controller()
+    controller._system_info = None
+
+    with pytest.raises(ValueError, match="firmware"):
+        light_group.build_topology(controller, "GROUP")
+
+
+@pytest.mark.asyncio
+async def test_multiple_cached_systems_reject_before_io(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    cached = make_projection("OFF")
+    cached["objectList"].append(_entry("SYS_2", OBJTYP="SYSTEM", VER="1.064", SERVICE="AUTO"))
+    controller = make_cached_controller_from_projection(cached)
+    connection = ScriptedConnection(
+        [make_projection("OFF"), make_projection("OFF"), final_projection("OFF")],
+        action_frames=action_frames("OFF"),
+    )
+    controller._connection = connection  # type: ignore[assignment]
+    _fast_lifecycle(monkeypatch)
+
+    with pytest.raises(ValueError, match="cached system"):
+        await controller.run_light_group_sync("GROUP")
+
+    assert connection.calls == []
+
+
+def test_cached_topology_and_projection_are_frozen_tuple_owned() -> None:
+    controller = make_cached_controller()
+    topology = light_group.build_topology(controller, "GROUP")
+    projection = light_group.parse_projection(make_projection("OFF"), topology)
+
+    assert isinstance(topology.target_rows, tuple)
+    assert isinstance(projection.circuits, tuple)
+    with pytest.raises(AttributeError):
+        topology.target_objnam = "OTHER"  # type: ignore[misc]
+
+
+@pytest.mark.parametrize(
+    "case",
+    [
+        "non_dict_response",
+        "missing_object_list",
+        "non_list_object_list",
+        "non_dict_entry",
+        "missing_objnam",
+        "empty_objnam",
+        "non_dict_params",
+        "duplicate_objnam",
+        "unknown_missing_type",
+        "unknown_placeholder_type",
+        "unknown_null_type",
+        "new_relevant_object",
+        "missing_relevant_object",
+        "missing_system",
+        "multiple_systems",
+        "changed_child_subtype",
+        "missing_circuit_status",
+        "missing_row_parent",
+        "row_parent_placeholder",
+        "row_parent_null",
+    ],
+)
+def test_projection_rejects_malformed_envelope_inventory_and_topology(case: str) -> None:
+    controller = make_cached_controller()
+    topology = light_group.build_topology(controller, "GROUP")
+    projection: Any = make_projection("OFF")
+    if case == "non_dict_response":
+        projection = []
+    elif case == "missing_object_list":
+        projection = {}
+    elif case == "non_list_object_list":
+        projection["objectList"] = {}
+    elif case == "non_dict_entry":
+        projection["objectList"].append("bad")
+    elif case == "missing_objnam":
+        projection["objectList"][-1].pop("objnam")
+    elif case == "empty_objnam":
+        projection["objectList"][-1]["objnam"] = ""
+    elif case == "non_dict_params":
+        projection["objectList"][-1]["params"] = []
+    elif case == "duplicate_objnam":
+        projection["objectList"].append(copy.deepcopy(projection["objectList"][0]))
+    elif case == "unknown_missing_type":
+        projection["objectList"][-1]["params"].pop("OBJTYP")
+    elif case == "unknown_placeholder_type":
+        projection["objectList"][-1]["params"]["OBJTYP"] = "OBJTYP"
+    elif case == "unknown_null_type":
+        projection["objectList"][-1]["params"]["OBJTYP"] = "00000"
+    elif case == "new_relevant_object":
+        projection["objectList"].append(
+            _entry("NEW", OBJTYP="CIRCUIT", SUBTYP="LIGHT", STATUS="OFF")
+        )
+    elif case == "missing_relevant_object":
+        projection["objectList"] = [
+            entry for entry in projection["objectList"] if entry["objnam"] != "AUX"
+        ]
+    elif case == "missing_system":
+        projection["objectList"] = [
+            entry for entry in projection["objectList"] if entry["objnam"] != "SYS"
+        ]
+    elif case == "multiple_systems":
+        projection["objectList"].append(
+            _entry("SYS_2", OBJTYP="SYSTEM", VER="1.064", SERVICE="AUTO")
+        )
+    elif case == "changed_child_subtype":
+        next(entry for entry in projection["objectList"] if entry["objnam"] == "CHILD_A")["params"][
+            "SUBTYP"
+        ] = "INTELLI"
+    elif case == "missing_circuit_status":
+        next(entry for entry in projection["objectList"] if entry["objnam"] == "AUX")["params"].pop(
+            "STATUS"
+        )
+    elif case == "missing_row_parent":
+        next(entry for entry in projection["objectList"] if entry["objnam"] == "ROW_A")[
+            "params"
+        ].pop("PARENT")
+    elif case == "row_parent_placeholder":
+        next(entry for entry in projection["objectList"] if entry["objnam"] == "ROW_A")["params"][
+            "PARENT"
+        ] = "PARENT"
+    elif case == "row_parent_null":
+        next(entry for entry in projection["objectList"] if entry["objnam"] == "ROW_A")["params"][
+            "PARENT"
+        ] = "00000"
+
+    with pytest.raises(ICError):
+        light_group.parse_projection(projection, topology)
+
+
+def test_projection_ignores_only_explicit_well_formed_unrelated_types() -> None:
+    controller = make_cached_controller()
+    topology = light_group.build_topology(controller, "GROUP")
+    projection = make_projection("OFF")
+    projection["objectList"].append(_entry("EXTRA", OBJTYP="MODULE", STATUS="ON"))
+
+    parsed = light_group.parse_projection(projection, topology)
+
+    assert all(item.objnam != "EXTRA" for item in parsed.circuits)
+
+
+@pytest.mark.parametrize("spelling", ["omitted", "USE", "00000"])
+def test_row_use_absence_spellings_normalize_to_equal_projection(spelling: str) -> None:
+    controller = make_cached_controller()
+    topology = light_group.build_topology(controller, "GROUP")
+    projection = make_projection("OFF")
+    row = next(entry for entry in projection["objectList"] if entry["objnam"] == "ROW_A")
+    if spelling == "omitted":
+        row["params"].pop("USE", None)
+    else:
+        row["params"]["USE"] = spelling
+
+    parsed = light_group.parse_projection(projection, topology)
+
+    assert next(item for item in parsed.rows if item.objnam == "ROW_A").use is None
+
+
+@pytest.mark.parametrize(
+    "case",
+    [
+        "wrong_version",
+        "wrong_service",
+        "group_flag_on",
+        "mixed_target_status",
+        "noncanonical_target_status",
+    ],
+)
+def test_initial_projection_rejects_every_fresh_global_gate(case: str) -> None:
+    controller = make_cached_controller()
+    topology = light_group.build_topology(controller, "GROUP")
+    projection = make_projection("OFF")
+    by_name = {entry["objnam"]: entry for entry in projection["objectList"]}
+    if case == "wrong_version":
+        by_name["SYS"]["params"]["VER"] = "1.064 "
+    elif case == "wrong_service":
+        by_name["SYS"]["params"]["SERVICE"] = "MANUAL"
+    elif case == "group_flag_on":
+        by_name["OTHER_GROUP"]["params"]["SET"] = "ON"
+    elif case == "mixed_target_status":
+        by_name["CHILD_A"]["params"]["STATUS"] = "ON"
+    elif case == "noncanonical_target_status":
+        by_name["GROUP"]["params"]["STATUS"] = "READY"
+        by_name["CHILD_A"]["params"]["STATUS"] = "READY"
+        by_name["CHILD_B"]["params"]["STATUS"] = "READY"
+
+    parsed = light_group.parse_projection(projection, topology)
+    with pytest.raises(ICError):
+        light_group.validate_initial_projection(parsed, topology)
+
+
+@pytest.mark.parametrize(
+    "case",
+    [
+        "target_off",
+        "unrelated_status",
+        "target_set",
+        "other_group_sync",
+        "row_use",
+        "system_service",
+    ],
+)
+def test_final_projection_rejects_every_authoritative_mismatch(case: str) -> None:
+    controller = make_cached_controller()
+    topology = light_group.build_topology(controller, "GROUP")
+    baseline = light_group.parse_projection(make_projection("OFF"), topology)
+    final_raw = final_projection("OFF")
+    by_name = {entry["objnam"]: entry for entry in final_raw["objectList"]}
+    if case == "target_off":
+        by_name["CHILD_A"]["params"]["STATUS"] = "OFF"
+    elif case == "unrelated_status":
+        by_name["AUX"]["params"]["STATUS"] = "ON"
+    elif case == "target_set":
+        by_name["GROUP"]["params"]["SET"] = "ON"
+    elif case == "other_group_sync":
+        by_name["OTHER_GROUP"]["params"]["SYNC"] = "ON"
+    elif case == "row_use":
+        by_name["ROW_A"]["params"]["USE"] = "REAL"
+    elif case == "system_service":
+        by_name["SYS"]["params"]["SERVICE"] = "MANUAL"
+    final = light_group.parse_projection(final_raw, topology)
+
+    with pytest.raises(ICError):
+        light_group.validate_final_projection(final, baseline, topology)
+
+
+def test_subscription_batches_have_deterministic_exact_coverage() -> None:
+    controller = make_cached_controller()
+    topology = light_group.build_topology(controller, "GROUP")
+
+    first = light_group.build_subscription_batches(topology)
+    second = light_group.build_subscription_batches(topology)
+
+    assert first == second
+    assert all(sum(len(item["keys"]) for item in batch) <= 50 for batch in first)
+    covered = [(item["objnam"], key) for batch in first for item in batch for key in item["keys"]]
+    assert len(covered) == len(set(covered))
+    assert {objnam for objnam, _key in covered} == {
+        topology.system_objnam,
+        *topology.circuit_objnams,
+        *topology.row_objnams,
+    }
+
+
+def test_subscription_batches_split_before_fifty_key_overflow() -> None:
+    cached = make_projection("OFF")
+    for index in range(3):
+        cached["objectList"].append(
+            _entry(
+                f"EXTRA_{index}",
+                OBJTYP="CIRCUIT",
+                SUBTYP="LIGHT",
+                STATUS="OFF",
+            )
+        )
+    controller = make_cached_controller_from_projection(cached)
+    topology = light_group.build_topology(controller, "GROUP")
+    baseline = light_group.parse_projection(cached, topology)
+
+    batches = light_group.build_subscription_batches(topology)
+
+    assert len(batches) >= 2
+    assert all(sum(len(item["keys"]) for item in batch) <= 50 for batch in batches)
+    covered = [(item["objnam"], key) for batch in batches for item in batch for key in item["keys"]]
+    assert len(covered) == len(set(covered))
+    for batch in batches:
+        light_group.validate_subscription_response(
+            _subscription_response(batch, cached), batch, baseline, topology
+        )
+
+
+@pytest.mark.parametrize(
+    "case",
+    [
+        "non_200",
+        "missing_message_id",
+        "empty_message_id",
+        "missing_object_list",
+        "empty_object_list",
+        "non_dict_entry",
+        "duplicate_object",
+        "unexpected_object",
+        "unexpected_key",
+        "missing_object",
+        "missing_mandatory_key",
+        "placeholder_mandatory",
+        "null_mandatory",
+        "malformed_optional",
+        "changed_optional",
+    ],
+)
+def test_subscription_initialization_rejects_malformed_or_mismatched_coverage(
+    case: str,
+) -> None:
+    controller = make_cached_controller()
+    topology = light_group.build_topology(controller, "GROUP")
+    baseline = light_group.parse_projection(make_projection("OFF"), topology)
+    request = light_group.build_subscription_batches(topology)[0]
+    response = _subscription_response(request)
+    object_list = response["objectList"]
+    if case == "non_200":
+        response["response"] = "500"
+    elif case == "missing_message_id":
+        response.pop("messageID")
+    elif case == "empty_message_id":
+        response["messageID"] = ""
+    elif case == "missing_object_list":
+        response.pop("objectList")
+    elif case == "empty_object_list":
+        response["objectList"] = []
+    elif case == "non_dict_entry":
+        object_list[0] = "bad"
+    elif case == "duplicate_object":
+        object_list.append(copy.deepcopy(object_list[0]))
+    elif case == "unexpected_object":
+        object_list[0]["objnam"] = "EXTRA"
+    elif case == "unexpected_key":
+        object_list[0]["params"]["EXTRA"] = "ON"
+    elif case == "missing_object":
+        object_list.pop()
+    elif case == "missing_mandatory_key":
+        next(entry for entry in object_list if entry["objnam"] == "ROW_A")["params"].pop("PARENT")
+    elif case == "placeholder_mandatory":
+        next(entry for entry in object_list if entry["objnam"] == "ROW_A")["params"]["PARENT"] = (
+            "PARENT"
+        )
+    elif case == "null_mandatory":
+        next(entry for entry in object_list if entry["objnam"] == "ROW_A")["params"]["PARENT"] = (
+            "00000"
+        )
+    elif case == "malformed_optional":
+        next(entry for entry in object_list if entry["objnam"] == "AUX")["params"]["PARENT"] = []
+    elif case == "changed_optional":
+        next(entry for entry in object_list if entry["objnam"] == "AUX")["params"]["PARENT"] = (
+            "REAL"
+        )
+
+    with pytest.raises(ICError):
+        light_group.validate_subscription_response(response, request, baseline, topology)
+
+
+@pytest.mark.parametrize("spelling", ["omitted", None, "PARENT", "00000"])
+def test_subscription_optional_absence_spellings_equal_baseline(spelling: str | None) -> None:
+    controller = make_cached_controller()
+    topology = light_group.build_topology(controller, "GROUP")
+    baseline = light_group.parse_projection(make_projection("OFF"), topology)
+    request = light_group.build_subscription_batches(topology)[0]
+    response = _subscription_response(request)
+    params = next(entry for entry in response["objectList"] if entry["objnam"] == "AUX")["params"]
+    if spelling == "omitted":
+        params.pop("PARENT", None)
+    else:
+        params["PARENT"] = spelling
+
+    light_group.validate_subscription_response(response, request, baseline, topology)
+
+
+@pytest.mark.parametrize("spelling", ["omitted", None, "USE", "00000"])
+def test_subscription_row_use_absence_spellings_equal_baseline(spelling: str | None) -> None:
+    controller = make_cached_controller()
+    topology = light_group.build_topology(controller, "GROUP")
+    baseline = light_group.parse_projection(make_projection("OFF"), topology)
+    request = light_group.build_subscription_batches(topology)[0]
+    response = _subscription_response(request)
+    params = next(entry for entry in response["objectList"] if entry["objnam"] == "ROW_A")["params"]
+    if spelling == "omitted":
+        params.pop("USE", None)
+    else:
+        params["USE"] = spelling
+
+    light_group.validate_subscription_response(response, request, baseline, topology)
+
+
+def test_subscription_row_use_real_value_is_retained_and_compared() -> None:
+    projection = make_projection("OFF")
+    next(entry for entry in projection["objectList"] if entry["objnam"] == "ROW_A")["params"][
+        "USE"
+    ] = "REAL"
+    controller = make_cached_controller_from_projection(projection)
+    topology = light_group.build_topology(controller, "GROUP")
+    baseline = light_group.parse_projection(projection, topology)
+    request = light_group.build_subscription_batches(topology)[0]
+    response = _subscription_response(request, projection)
+
+    light_group.validate_subscription_response(response, request, baseline, topology)
+    next(entry for entry in response["objectList"] if entry["objnam"] == "ROW_A")["params"][
+        "USE"
+    ] = "CHANGED"
+    with pytest.raises(ICError, match="differs from baseline"):
+        light_group.validate_subscription_response(response, request, baseline, topology)
+
+
+@pytest.mark.parametrize(
+    ("objnam", "key"),
+    [
+        ("SYS", "VER"),
+        ("GROUP", "STATUS"),
+        ("GROUP", "SYNC"),
+        ("ROW_A", "PARENT"),
+        ("ROW_A", "CIRCUIT"),
+        ("ROW_A", "LISTORD"),
+    ],
+)
+def test_projection_rejects_null_reference_in_every_mandatory_field(
+    objnam: str,
+    key: str,
+) -> None:
+    controller = make_cached_controller()
+    topology = light_group.build_topology(controller, "GROUP")
+    projection = make_projection("OFF")
+    next(entry for entry in projection["objectList"] if entry["objnam"] == objnam)["params"][
+        key
+    ] = "00000"
+
+    with pytest.raises(ICError, match="mandatory"):
+        light_group.parse_projection(projection, topology)
+
+
+@pytest.mark.parametrize("value", [None, "PARENT", "00000"])
+def test_projection_normalizes_declared_optional_absence(value: str | None) -> None:
+    controller = make_cached_controller()
+    topology = light_group.build_topology(controller, "GROUP")
+    projection = make_projection("OFF")
+    aux = next(entry for entry in projection["objectList"] if entry["objnam"] == "AUX")
+    aux["params"]["PARENT"] = value
+
+    parsed = light_group.parse_projection(projection, topology)
+
+    assert next(item for item in parsed.circuits if item.objnam == "AUX").parent is None
+
+
+def test_projection_rejects_non_string_non_null_optional_value() -> None:
+    controller = make_cached_controller()
+    topology = light_group.build_topology(controller, "GROUP")
+    projection = make_projection("OFF")
+    aux = next(entry for entry in projection["objectList"] if entry["objnam"] == "AUX")
+    aux["params"]["PARENT"] = 7
+
+    with pytest.raises(ICError, match="optional PARENT"):
+        light_group.parse_projection(projection, topology)
+
+
+@pytest.mark.parametrize(
+    "frame",
+    [
+        {"command": "NotifyList", "objectList": [_entry("GROUP", STATUS="ON")]},
+        {"command": "NotifyList", "objectList": [_entry("GROUP", SYNC="ON")]},
+    ],
+)
+def test_every_projected_target_delta_before_write_is_irreversible(frame: dict[str, Any]) -> None:
+    tracker = _tracker()
+
+    tracker.observe(1, frame)
+
+    with pytest.raises(ICError, match="invariant"):
+        tracker.raise_if_failed()
+    assert not tracker.write_started.is_set()
+
+
+def test_notification_entries_are_processed_in_wire_order() -> None:
+    tracker = _tracker()
+
+    tracker.observe(
+        1,
+        {
+            "command": "NotifyList",
+            "objectList": [
+                _entry("AUX", STATUS="ON"),
+                _entry("AUX", STATUS="OFF"),
+            ],
+        },
+    )
+
+    with pytest.raises(ICError, match="AUX.STATUS"):
+        tracker.raise_if_failed()
+
+
+def test_equal_duplicate_notification_entries_are_harmless() -> None:
+    tracker = _tracker()
+
+    tracker.observe(
+        1,
+        {
+            "command": "NotifyList",
+            "objectList": [
+                _entry("AUX", STATUS="OFF"),
+                _entry("AUX", STATUS="OFF"),
+            ],
+        },
+    )
+
+    tracker.raise_if_failed()
+
+
+def test_prebaseline_notification_is_copied_and_replayed() -> None:
+    controller = make_cached_controller()
+    topology = light_group.build_topology(controller, "GROUP")
+    tracker = light_group.LightGroupSyncTracker(topology)
+    frame = {"command": "NotifyList", "objectList": [_entry("AUX", STATUS="ON")]}
+
+    tracker.observe(1, frame)
+    frame["objectList"][0]["params"]["STATUS"] = "OFF"
+    tracker.set_prewrite_baseline(light_group.parse_projection(make_projection("OFF"), topology))
+
+    with pytest.raises(ICError, match="AUX.STATUS"):
+        tracker.raise_if_failed()
+
+
+def test_prebaseline_notification_overflow_fails_closed(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    controller = make_cached_controller()
+    topology = light_group.build_topology(controller, "GROUP")
+    tracker = light_group.LightGroupSyncTracker(topology)
+    monkeypatch.setattr(light_group, "MAX_PREBASELINE_NOTIFICATIONS", 2)
+    frame = {"command": "NotifyList", "objectList": [_entry("AUX", STATUS="OFF")]}
+
+    tracker.observe(1, frame)
+    tracker.observe(2, frame)
+    tracker.observe(3, frame)
+
+    with pytest.raises(ICError, match="buffer overflow"):
+        tracker.raise_if_failed()
+
+
+@pytest.mark.parametrize("post_dispatch", [False, True])
+@pytest.mark.parametrize(
+    "frame",
+    [
+        {},
+        {"command": "NotifyList", "objectList": {}},
+        {"command": "NotifyList", "objectList": ["bad"]},
+        {"command": "NotifyList", "objectList": [{"params": {"STATUS": "ON"}}]},
+        {"command": "NotifyList", "objectList": [{"objnam": 7, "params": {}}]},
+        {"command": "NotifyList", "objectList": [{"objnam": "AUX", "params": []}]},
+        {"command": "NotifyList", "objectList": [_entry("AUX", STATUS="STATUS")]},
+        {"command": "NotifyList", "objectList": [_entry("AUX", STATUS="00000")]},
+        {"command": "NotifyList", "objectList": [_entry("AUX", PARENT=[])]},
+        {"command": "NotifyList", "objectList": [_entry("NEW", STATUS="ON")]},
+        {"command": "NotifyList", "objectList": [_entry("NEW", OBJTYP="CIRCUIT")]},
+        {"command": "NotifyList", "objectList": [_entry("NEW", OBJTYP="00000")]},
+        {"command": "NotifyList", "objectList": [_entry("IGNORED", OBJTYP=None)]},
+        {"command": "NotifyList", "objectList": [_entry("IGNORED", OBJTYP="00000")]},
+    ],
+)
+def test_malformed_raw_notifications_fail_synchronously_in_every_phase(
+    frame: dict[str, Any],
+    post_dispatch: bool,
+) -> None:
+    tracker = _tracker()
+    if post_dispatch:
+        tracker.mark_before_write(0, 10.0)
+        tracker.mark_after_write(0)
+
+    tracker.observe(1, frame)
+
+    assert tracker.failure_event.is_set()
+    with pytest.raises(ICError):
+        tracker.raise_if_failed()
+
+
+def test_first_tracker_failure_is_never_replaced() -> None:
+    tracker = _tracker()
+    tracker.observe(1, {"command": "NotifyList", "objectList": [_entry("AUX", STATUS="ON")]})
+    first = tracker.failure
+
+    tracker.observe(2, {})
+
+    assert tracker.failure is first
+    assert tracker.failure_event.is_set()
+
+
+def test_cached_irrelevant_object_partial_updates_remain_ignored() -> None:
+    tracker = _tracker()
+
+    tracker.observe(1, {"command": "NotifyList", "objectList": [_entry("IGNORED", STATUS="ON")]})
+    tracker.observe(
+        2,
+        {"command": "NotifyList", "objectList": [_entry("IGNORED", OBJTYP="MODULE")]},
+    )
+
+    tracker.raise_if_failed()
+
+
+def test_irrelevant_object_transition_into_relevant_type_is_irreversible() -> None:
+    tracker = _tracker()
+
+    tracker.observe(
+        1,
+        {"command": "NotifyList", "objectList": [_entry("IGNORED", OBJTYP="CIRCUIT")]},
+    )
+    tracker.observe(
+        2,
+        {"command": "NotifyList", "objectList": [_entry("IGNORED", OBJTYP="MODULE")]},
+    )
+
+    with pytest.raises(ICError, match="relevance"):
+        tracker.raise_if_failed()
+
+
+def test_new_explicit_irrelevant_object_can_be_tracked_until_relevance_changes() -> None:
+    tracker = _tracker()
+
+    tracker.observe(
+        1,
+        {"command": "NotifyList", "objectList": [_entry("NEW", OBJTYP="SENSOR")]},
+    )
+    tracker.observe(2, {"command": "NotifyList", "objectList": [_entry("NEW", VALUE="7")]})
+    tracker.raise_if_failed()
+    tracker.observe(
+        3,
+        {"command": "NotifyList", "objectList": [_entry("NEW", OBJTYP="SYSTEM")]},
+    )
+
+    with pytest.raises(ICError, match="relevance"):
+        tracker.raise_if_failed()
+
+
+@pytest.mark.parametrize("objnam", ["GROUP", "AUX", "ROW_A"])
+@pytest.mark.parametrize("spelling", [None, "USE", "00000"])
+def test_optional_notification_absence_spellings_compare_semantically(
+    objnam: str,
+    spelling: str | None,
+) -> None:
+    tracker = _tracker()
+
+    tracker.observe(
+        1,
+        {"command": "NotifyList", "objectList": [_entry(objnam, USE=spelling)]},
+    )
+
+    tracker.raise_if_failed()
+
+
+@pytest.mark.parametrize("spelling", ["PARENT", "00000"])
+def test_present_row_parent_placeholder_is_always_malformed(spelling: str) -> None:
+    tracker = _tracker()
+
+    tracker.observe(
+        1,
+        {"command": "NotifyList", "objectList": [_entry("ROW_A", PARENT=spelling)]},
+    )
+
+    with pytest.raises(ICError, match="mandatory"):
+        tracker.raise_if_failed()
+
+
+def test_partial_row_notification_may_omit_parent_and_use() -> None:
+    tracker = _tracker()
+
+    tracker.observe(
+        1,
+        {"command": "NotifyList", "objectList": [_entry("ROW_A", LISTORD="1")]},
+    )
+
+    tracker.raise_if_failed()
+
+
+def test_before_write_uses_supplied_clock_and_fails_before_marking_dispatch() -> None:
+    tracker = _tracker()
+    tracker.observe(1, {"command": "NotifyList", "objectList": [_entry("AUX", STATUS="ON")]})
+
+    with pytest.raises(ICError):
+        tracker.mark_before_write(7, 123.5)
+
+    assert not tracker.write_started.is_set()
+    assert tracker.write_started_at is None
+    assert tracker.action_deadline is None
+
+
+def test_before_write_records_exact_absolute_deadline() -> None:
+    tracker = _tracker()
+
+    tracker.mark_before_write(7, 123.5)
+
+    assert tracker.pre_send_sequence == 7
+    assert tracker.write_started_at == 123.5
+    assert tracker.action_deadline == 183.5
+    assert tracker.write_started.is_set()
+
+
+@pytest.mark.asyncio
+async def test_pre_watermark_sync_cannot_qualify_but_status_invariants_stay_live() -> None:
+    tracker = _tracker()
+    tracker.mark_before_write(0, asyncio.get_running_loop().time())
+
+    tracker.observe(1, {"command": "NotifyList", "objectList": [_entry("GROUP", SYNC="ON")]})
+    tracker.observe(2, {"command": "NotifyList", "objectList": [_entry("GROUP", STATUS="ON")]})
+    tracker.observe(3, {"command": "NotifyList", "objectList": [_entry("CHILD_A", STATUS="ON")]})
+
+    assert not tracker.onset_event.is_set()
+    tracker.raise_if_failed()
+
+
+@pytest.mark.asyncio
+async def test_sync_edges_must_be_strictly_after_watermark_and_ordered() -> None:
+    tracker = _tracker()
+    tracker.mark_before_write(0, asyncio.get_running_loop().time())
+    tracker.mark_after_write(5)
+
+    tracker.observe(5, {"command": "NotifyList", "objectList": [_entry("GROUP", SYNC="ON")]})
+    tracker.observe(6, {"command": "NotifyList", "objectList": [_entry("GROUP", SYNC="OFF")]})
+    assert not tracker.onset_event.is_set()
+    assert not tracker.terminal_event.is_set()
+    tracker.observe(7, {"command": "NotifyList", "objectList": [_entry("GROUP", SYNC="ON")]})
+    assert tracker.onset_event.is_set()
+    assert not tracker.terminal_event.is_set()
+    tracker.observe(8, {"command": "NotifyList", "objectList": [_entry("GROUP", SYNC="OFF")]})
+
+    assert tracker.terminal_event.is_set()
+    assert tracker.terminal_time is not None
+
+
+@pytest.mark.asyncio
+async def test_post_terminal_sync_reentry_is_irreversible() -> None:
+    tracker = _tracker()
+    tracker.mark_before_write(0, asyncio.get_running_loop().time())
+    tracker.mark_after_write(0)
+    tracker.observe(1, {"command": "NotifyList", "objectList": [_entry("GROUP", SYNC="ON")]})
+    tracker.observe(2, {"command": "NotifyList", "objectList": [_entry("GROUP", SYNC="OFF")]})
+    tracker.observe(3, {"command": "NotifyList", "objectList": [_entry("GROUP", SYNC="ON")]})
+    tracker.observe(4, {"command": "NotifyList", "objectList": [_entry("GROUP", SYNC="OFF")]})
+
+    with pytest.raises(ICError, match="re-entered"):
+        tracker.raise_if_failed()
+
+
+@pytest.mark.asyncio
+async def test_all_off_target_status_is_monotonic_per_object() -> None:
+    tracker = _tracker("OFF")
+    tracker.mark_before_write(0, asyncio.get_running_loop().time())
+
+    tracker.observe(1, {"command": "NotifyList", "objectList": [_entry("CHILD_A", STATUS="OFF")]})
+    tracker.observe(2, {"command": "NotifyList", "objectList": [_entry("CHILD_A", STATUS="ON")]})
+    tracker.observe(3, {"command": "NotifyList", "objectList": [_entry("CHILD_A", STATUS="OFF")]})
+
+    with pytest.raises(ICError, match="returned off"):
+        tracker.raise_if_failed()
+
+
+@pytest.mark.asyncio
+async def test_all_on_target_may_never_report_off() -> None:
+    tracker = _tracker("ON")
+    tracker.mark_before_write(0, asyncio.get_running_loop().time())
+
+    tracker.observe(1, {"command": "NotifyList", "objectList": [_entry("GROUP", STATUS="OFF")]})
+
+    with pytest.raises(ICError, match="all-on"):
+        tracker.raise_if_failed()
+
+
+@pytest.mark.parametrize(
+    "entry",
+    [
+        _entry("GROUP", USE="CHANGED"),
+        _entry("GROUP", SET="ON"),
+        _entry("GROUP", SWIM="ON"),
+        _entry("AUX", STATUS="ON"),
+        _entry("AUX", PARENT="CHANGED"),
+        _entry("OTHER_GROUP", SYNC="ON"),
+        _entry("ROW_A", CIRCUIT="CHILD_B"),
+        _entry("ROW_A", LISTORD="2"),
+        _entry("ROW_A", USE="REAL"),
+        _entry("SYS", SERVICE="MANUAL"),
+    ],
+)
+def test_post_dispatch_collateral_invariants_fail_immediately(entry: dict[str, Any]) -> None:
+    tracker = _tracker()
+    tracker.mark_before_write(0, 10.0)
+
+    tracker.observe(1, {"command": "NotifyList", "objectList": [entry]})
+
+    with pytest.raises(ICError, match="invariant"):
+        tracker.raise_if_failed()
+
+
+def _fast_lifecycle(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setattr(light_group, "SUBSCRIPTION_SETTLE_SECONDS", 0)
+    monkeypatch.setattr(light_group, "SYNC_POST_TERMINAL_OBSERVATION_SECONDS", 0)
+
+
+def _capture_tracker(
+    monkeypatch: pytest.MonkeyPatch,
+) -> list[light_group.LightGroupSyncTracker]:
+    real_tracker = light_group.LightGroupSyncTracker
+    captured: list[light_group.LightGroupSyncTracker] = []
+
+    def factory(
+        topology: light_group.LightGroupTopology,
+    ) -> light_group.LightGroupSyncTracker:
+        tracker = real_tracker(topology)
+        captured.append(tracker)
+        return tracker
+
+    monkeypatch.setattr(light_group, "LightGroupSyncTracker", factory)
+    return captured
+
+
+def _deadline_barrier(monkeypatch: pytest.MonkeyPatch) -> asyncio.Event:
+    expired = asyncio.Event()
+
+    async def wait_deadline(_deadline: float) -> None:
+        await expired.wait()
+
+    monkeypatch.setattr(light_group, "_wait_deadline", wait_deadline)
+    return expired
+
+
+async def _eventually(predicate: Any) -> None:
+    for _attempt in range(100):
+        if predicate():
+            return
+        await asyncio.sleep(0)
+    raise AssertionError("condition did not become true")
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("stage", ["first", "subscription", "second"])
+async def test_prewrite_observer_failure_wakes_each_network_gate(
+    monkeypatch: pytest.MonkeyPatch,
+    stage: str,
+) -> None:
+    controller, connection = make_controller()
+    _fast_lifecycle(monkeypatch)
+    key = {
+        "first": ("GetParamList", 1),
+        "subscription": ("RequestParamList", 1),
+        "second": ("GetParamList", 2),
+    }[stage]
+    connection.before_response_frames[key] = [
+        {"command": "NotifyList", "objectList": [_entry("AUX", STATUS="ON")]}
+    ]
+
+    with pytest.raises(ICError, match="AUX.STATUS") as raised:
+        await controller.run_light_group_sync("GROUP")
+
+    assert not isinstance(raised.value, ICLightGroupError)
+    assert all(call.command != "SetParamList" for call in connection.calls)
+    assert connection.observers == []
+
+
+@pytest.mark.asyncio
+async def test_equal_notification_in_first_response_turn_is_harmless(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    controller, connection = make_controller()
+    _fast_lifecycle(monkeypatch)
+    connection.before_response_frames[("GetParamList", 1)] = [
+        {"command": "NotifyList", "objectList": [_entry("AUX", STATUS="OFF")]}
+    ]
+
+    ack = await controller.run_light_group_sync("GROUP")
+
+    assert ack is connection.action_response
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize(
+    "frame",
+    [
+        {},
+        {"command": "NotifyList", "objectList": ["bad"]},
+        {"command": "NotifyList", "objectList": [_entry("NEW", OBJTYP="CIRCUIT")]},
+    ],
+)
+async def test_structural_prebaseline_failure_wakes_a_blocked_first_read(
+    monkeypatch: pytest.MonkeyPatch,
+    frame: dict[str, Any],
+) -> None:
+    controller, connection = make_controller()
+    captured = _capture_tracker(monkeypatch)
+    first_read_sent = asyncio.Event()
+
+    async def blocked_first_read(
+        conn: ScriptedConnection,
+        before: Any,
+        after: Any,
+        _kwargs: dict[str, Any],
+    ) -> dict[str, Any]:
+        before(conn._sequence, asyncio.get_running_loop().time())
+        if after is not None:
+            after(conn._sequence)
+        first_read_sent.set()
+        await asyncio.Event().wait()
+        raise AssertionError
+
+    connection.scripts[("GetParamList", 1)] = blocked_first_read
+    task = asyncio.create_task(controller.run_light_group_sync("GROUP"))
+    await first_read_sent.wait()
+    try:
+        connection.emit(frame)
+        assert captured[0].failure_event.is_set()
+        with pytest.raises(ICError):
+            await task
+    finally:
+        if not task.done():
+            task.cancel()
+            with contextlib.suppress(asyncio.CancelledError):
+                await task
+
+    assert connection.observers == []
+    assert connection.remove_count == 1
+    assert all(call.command != "SetParamList" for call in connection.calls)
+
+
+@pytest.mark.asyncio
+async def test_projected_change_while_action_waits_to_write_stays_pre_dispatch(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    controller, connection = make_controller()
+    _fast_lifecycle(monkeypatch)
+    connection.before_write_frames = [
+        {"command": "NotifyList", "objectList": [_entry("GROUP", SYNC="ON")]}
+    ]
+
+    with pytest.raises(ICError, match="GROUP.SYNC") as raised:
+        await controller.run_light_group_sync("GROUP")
+
+    assert not isinstance(raised.value, ICLightGroupError)
+    assert len([call for call in connection.calls if call.command == "SetParamList"]) == 1
+    assert connection.observers == []
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize(
+    ("scenario", "phase", "response_received", "acknowledged", "onset_seen"),
+    [
+        ("no_response", "acknowledgement", False, False, False),
+        ("onset_no_response", "acknowledgement", False, False, True),
+        ("ack_no_onset", "onset", True, True, False),
+        ("onset_no_terminal", "terminal", True, True, True),
+        ("stalled_send", "acknowledgement", False, False, False),
+    ],
+)
+async def test_absolute_action_deadline_reports_exact_certainty_metadata(
+    monkeypatch: pytest.MonkeyPatch,
+    scenario: str,
+    phase: str,
+    response_received: bool,
+    acknowledged: bool,
+    onset_seen: bool,
+) -> None:
+    controller, connection = make_controller(frames=[])
+    monkeypatch.setattr(light_group, "SUBSCRIPTION_SETTLE_SECONDS", 0)
+    deadline = _deadline_barrier(monkeypatch)
+    captured = _capture_tracker(monkeypatch)
+    never = asyncio.Event()
+    if scenario in {"no_response", "onset_no_response"}:
+        connection.action_response_gate = never
+    if scenario in {"onset_no_response", "onset_no_terminal"}:
+        connection.action_frames = [
+            {"command": "NotifyList", "objectList": [_entry("GROUP", SYNC="ON")]}
+        ]
+    elif scenario == "stalled_send":
+        connection.action_gate = never
+
+    task = asyncio.create_task(controller.run_light_group_sync("GROUP"))
+    await _eventually(lambda: bool(captured) and captured[0].write_started.is_set())
+    tracker = captured[0]
+    if scenario == "ack_no_onset":
+        await _eventually(lambda: tracker.acknowledged)
+    elif scenario == "onset_no_terminal":
+        await _eventually(lambda: tracker.acknowledged and tracker.onset_seen)
+    elif scenario == "onset_no_response":
+        await _eventually(lambda: tracker.onset_seen)
+    deadline.set()
+
+    with pytest.raises(ICLightGroupError) as raised:
+        await task
+
+    error = raised.value
+    assert error.phase == phase
+    assert error.dispatch_started is True
+    assert error.response_received is response_received
+    assert error.acknowledged is acknowledged
+    assert error.onset_seen is onset_seen
+    assert connection.observers == []
+    assert len([call for call in connection.calls if call.command == "SetParamList"]) == 1
+    assert all(
+        call.kwargs["objectList"][0]["params"] == {"SYNC": "ON"}
+        for call in connection.calls
+        if call.command == "SetParamList"
+    )
+
+
+@pytest.mark.asyncio
+async def test_already_expired_absolute_deadline_beats_ready_action_success(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    controller, connection = make_controller(frames=[])
+    _fast_lifecycle(monkeypatch)
+
+    async def complete_after_expired_start(
+        conn: ScriptedConnection,
+        before: Any,
+        after: Any,
+        _kwargs: dict[str, Any],
+    ) -> dict[str, Any]:
+        before(conn._sequence, asyncio.get_running_loop().time() - 61.0)
+        after(conn._sequence)
+        for frame in action_frames("OFF"):
+            conn.emit(frame)
+        return conn.action_response
+
+    connection.scripts[("SetParamList", 1)] = complete_after_expired_start
+
+    with pytest.raises(ICLightGroupError) as raised:
+        await controller.run_light_group_sync("GROUP")
+
+    assert raised.value.phase == "acknowledgement"
+    assert raised.value.dispatch_started is True
+    assert len([call for call in connection.calls if call.command == "SetParamList"]) == 1
+    assert [call.command for call in connection.calls].count("GetParamList") == 2
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize(
+    "kind", ["non_200", "missing_message_id", "empty_message_id", "command_error"]
+)
+async def test_explicit_action_response_errors_are_acknowledgement_failures(
+    monkeypatch: pytest.MonkeyPatch,
+    kind: str,
+) -> None:
+    controller, connection = make_controller(frames=[])
+    _fast_lifecycle(monkeypatch)
+    if kind == "non_200":
+        connection.action_response = {"messageID": "4", "response": "500"}
+    elif kind == "missing_message_id":
+        connection.action_response = {"response": "200"}
+    elif kind == "empty_message_id":
+        connection.action_response = {"messageID": "", "response": "200"}
+    else:
+        connection.action_error = ICCommandError("500")
+
+    with pytest.raises(ICLightGroupError) as raised:
+        await controller.run_light_group_sync("GROUP")
+
+    assert raised.value.phase == "acknowledgement"
+    assert raised.value.response_received is True
+    assert raised.value.acknowledged is False
+    assert raised.value.onset_seen is False
+    assert len([call for call in connection.calls if call.command == "SetParamList"]) == 1
+
+
+@pytest.mark.asyncio
+async def test_action_timeout_before_response_has_uncertain_delivery_metadata(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    controller, connection = make_controller(frames=[])
+    _fast_lifecycle(monkeypatch)
+    connection.action_error = TimeoutError("response timeout")
+
+    with pytest.raises(ICLightGroupError) as raised:
+        await controller.run_light_group_sync("GROUP")
+
+    assert raised.value.phase == "acknowledgement"
+    assert raised.value.response_received is False
+    assert raised.value.acknowledged is False
+    assert raised.value.onset_seen is False
+
+
+@pytest.mark.asyncio
+async def test_invariant_between_before_and_after_write_fails_post_dispatch(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    controller, connection = make_controller(frames=[])
+    _fast_lifecycle(monkeypatch)
+    connection.between_write_frames = [
+        {"command": "NotifyList", "objectList": [_entry("AUX", STATUS="ON")]}
+    ]
+
+    with pytest.raises(ICLightGroupError) as raised:
+        await controller.run_light_group_sync("GROUP")
+
+    assert raised.value.phase == "acknowledgement"
+    assert raised.value.dispatch_started is True
+    assert raised.value.response_received is False
+
+
+@pytest.mark.asyncio
+async def test_pre_watermark_sync_on_needs_a_fresh_post_watermark_onset(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    controller, connection = make_controller(frames=[])
+    monkeypatch.setattr(light_group, "SUBSCRIPTION_SETTLE_SECONDS", 0)
+    deadline = _deadline_barrier(monkeypatch)
+    captured = _capture_tracker(monkeypatch)
+    connection.between_write_frames = [
+        {"command": "NotifyList", "objectList": [_entry("GROUP", SYNC="ON")]}
+    ]
+    connection.action_frames = [
+        {"command": "NotifyList", "objectList": [_entry("GROUP", SYNC="OFF")]}
+    ]
+    task = asyncio.create_task(controller.run_light_group_sync("GROUP"))
+    await _eventually(lambda: bool(captured) and captured[0].acknowledged)
+    assert captured[0].onset_seen is False
+    deadline.set()
+
+    with pytest.raises(ICLightGroupError) as raised:
+        await task
+
+    assert raised.value.phase == "onset"
+    assert raised.value.acknowledged is True
+    assert raised.value.onset_seen is False
+
+
+@pytest.mark.asyncio
+async def test_post_terminal_invariant_failure_is_observation_phase(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    controller, connection = make_controller()
+    monkeypatch.setattr(light_group, "SUBSCRIPTION_SETTLE_SECONDS", 0)
+    captured = _capture_tracker(monkeypatch)
+    task = asyncio.create_task(controller.run_light_group_sync("GROUP"))
+    await _eventually(
+        lambda: bool(captured) and captured[0].acknowledged and captured[0].terminal_event.is_set()
+    )
+    connection.emit({"command": "NotifyList", "objectList": [_entry("AUX", STATUS="ON")]})
+
+    with pytest.raises(ICLightGroupError) as raised:
+        await task
+
+    assert raised.value.phase == "observation"
+    assert raised.value.response_received is True
+    assert raised.value.acknowledged is True
+    assert raised.value.onset_seen is True
+    assert [call.command for call in connection.calls].count("GetParamList") == 2
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize(
+    "case",
+    ["target_status", "unrelated_status", "group_flag", "row_use", "system_service", "subtype"],
+)
+async def test_final_projection_mismatch_has_final_phase_metadata(
+    monkeypatch: pytest.MonkeyPatch,
+    case: str,
+) -> None:
+    final_raw = final_projection("OFF")
+    by_name = {entry["objnam"]: entry for entry in final_raw["objectList"]}
+    if case == "target_status":
+        by_name["CHILD_A"]["params"]["STATUS"] = "OFF"
+    elif case == "unrelated_status":
+        by_name["AUX"]["params"]["STATUS"] = "ON"
+    elif case == "group_flag":
+        by_name["OTHER_GROUP"]["params"]["SYNC"] = "ON"
+    elif case == "row_use":
+        by_name["ROW_A"]["params"]["USE"] = "REAL"
+    elif case == "system_service":
+        by_name["SYS"]["params"]["SERVICE"] = "MANUAL"
+    elif case == "subtype":
+        by_name["CHILD_A"]["params"]["SUBTYP"] = "INTELLI"
+    controller = make_cached_controller()
+    connection = ScriptedConnection(
+        [make_projection("OFF"), make_projection("OFF"), final_raw],
+        action_frames=action_frames("OFF"),
+    )
+    controller._connection = connection  # type: ignore[assignment]
+    _fast_lifecycle(monkeypatch)
+
+    with pytest.raises(ICLightGroupError) as raised:
+        await controller.run_light_group_sync("GROUP")
+
+    assert raised.value.phase == "final_projection"
+    assert raised.value.response_received is True
+    assert raised.value.acknowledged is True
+    assert raised.value.onset_seen is True
+    assert connection.observers == []
+
+
+@pytest.mark.asyncio
+async def test_unsafe_notification_during_final_read_wins_over_clean_response(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    controller, connection = make_controller()
+    _fast_lifecycle(monkeypatch)
+    connection.before_response_frames[("GetParamList", 3)] = [
+        {"command": "NotifyList", "objectList": [_entry("AUX", STATUS="ON")]}
+    ]
+
+    with pytest.raises(ICLightGroupError) as raised:
+        await controller.run_light_group_sync("GROUP")
+
+    assert raised.value.phase == "final_projection"
+    assert "AUX.STATUS" in str(raised.value.__cause__)
+    assert connection.observers == []
+
+
+@pytest.mark.asyncio
+async def test_normalized_row_use_spellings_compare_across_all_three_reads(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    first = make_projection("OFF")
+    second = make_projection("OFF")
+    final = final_projection("OFF")
+    next(entry for entry in first["objectList"] if entry["objnam"] == "ROW_A")["params"].pop(
+        "USE", None
+    )
+    next(entry for entry in second["objectList"] if entry["objnam"] == "ROW_A")["params"]["USE"] = (
+        "USE"
+    )
+    next(entry for entry in final["objectList"] if entry["objnam"] == "ROW_A")["params"]["USE"] = (
+        "00000"
+    )
+    controller = make_cached_controller()
+    connection = ScriptedConnection([first, second, final], action_frames=action_frames("OFF"))
+    controller._connection = connection  # type: ignore[assignment]
+    _fast_lifecycle(monkeypatch)
+
+    ack = await controller.run_light_group_sync("GROUP")
+
+    assert ack is connection.action_response
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("transport", ["tcp", "websocket"])
+async def test_onset_may_lead_target_status_transitions(
+    monkeypatch: pytest.MonkeyPatch,
+    transport: str,
+) -> None:
+    frames = [
+        {"command": "NotifyList", "objectList": [_entry("GROUP", SYNC="ON")]},
+        {"command": "NotifyList", "objectList": [_entry("CHILD_A", STATUS="ON")]},
+        {"command": "NotifyList", "objectList": [_entry("GROUP", STATUS="ON")]},
+        {"command": "NotifyList", "objectList": [_entry("CHILD_B", STATUS="ON")]},
+        {"command": "NotifyList", "objectList": [_entry("GROUP", SYNC="OFF")]},
+    ]
+    controller, connection = make_controller(frames=frames)
+    controller._transport = transport
+    _fast_lifecycle(monkeypatch)
+
+    ack = await controller.run_light_group_sync("GROUP")
+
+    assert ack is connection.action_response
+
+
+@pytest.mark.asyncio
+async def test_observation_wait_uses_exact_terminal_plus_sixty_boundary(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    controller, connection = make_controller()
+    monkeypatch.setattr(light_group, "SUBSCRIPTION_SETTLE_SECONDS", 0)
+    captured = _capture_tracker(monkeypatch)
+    observation_started = asyncio.Event()
+    release_observation = asyncio.Event()
+    deadlines: list[float] = []
+
+    async def wait_until(deadline: float) -> None:
+        deadlines.append(deadline)
+        observation_started.set()
+        await release_observation.wait()
+
+    monkeypatch.setattr(light_group, "_sleep_until", wait_until)
+    task = asyncio.create_task(controller.run_light_group_sync("GROUP"))
+    await observation_started.wait()
+
+    assert captured[0].terminal_time is not None
+    assert deadlines == [captured[0].terminal_time + 60.0]
+    assert [call.command for call in connection.calls].count("GetParamList") == 2
+    release_observation.set()
+    ack = await task
+
+    assert ack is connection.action_response
+    assert [call.command for call in connection.calls].count("GetParamList") == 3
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("stage", ["first", "subscription", "second", "action"])
+async def test_same_instance_reconnect_before_transport_is_pre_dispatch_and_close_wins(
+    monkeypatch: pytest.MonkeyPatch,
+    stage: str,
+) -> None:
+    controller, connection = make_controller()
+    _fast_lifecycle(monkeypatch)
+    key = {
+        "first": ("GetParamList", 1),
+        "subscription": ("RequestParamList", 1),
+        "second": ("GetParamList", 2),
+        "action": ("SetParamList", 1),
+    }[stage]
+    captured_old: list[asyncio.Future[None]] = []
+
+    async def reconnect_before_write(
+        conn: ScriptedConnection,
+        before: Any,
+        _after: Any,
+        _kwargs: dict[str, Any],
+    ) -> dict[str, Any]:
+        captured_old.append(conn.reconnect_same_instance())
+        conn.emit({"command": "NotifyList", "objectList": [_entry("GROUP", SYNC="ON")]})
+        if before is not None:
+            before(conn._sequence, asyncio.get_running_loop().time())
+        raise AssertionError("transport callback should reject the old generation")
+
+    connection.scripts[key] = reconnect_before_write
+
+    with pytest.raises(ICConnectionError) as raised:
+        await controller.run_light_group_sync("GROUP")
+
+    assert not isinstance(raised.value, ICLightGroupError)
+    assert captured_old and captured_old[0].done() and not captured_old[0].cancelled()
+    assert connection.capture_count == 1
+    assert connection.observers == []
+    if stage != "action":
+        assert all(call.command != "SetParamList" for call in connection.calls)
+
+
+@pytest.mark.asyncio
+async def test_same_instance_reconnect_after_dispatch_rejects_new_generation_edges(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    controller, connection = make_controller(frames=[])
+    _fast_lifecycle(monkeypatch)
+    captured_old: list[asyncio.Future[None]] = []
+
+    async def reconnect_after_dispatch(
+        conn: ScriptedConnection,
+        before: Any,
+        after: Any,
+        _kwargs: dict[str, Any],
+    ) -> dict[str, Any]:
+        before(conn._sequence, asyncio.get_running_loop().time())
+        after(conn._sequence)
+        captured_old.append(conn.reconnect_same_instance())
+        conn.emit(
+            {
+                "command": "NotifyList",
+                "objectList": [_entry("GROUP", SYNC="ON"), _entry("GROUP", SYNC="OFF")],
+            }
+        )
+        await asyncio.Event().wait()
+        raise AssertionError
+
+    connection.scripts[("SetParamList", 1)] = reconnect_after_dispatch
+
+    with pytest.raises(ICLightGroupError) as raised:
+        await controller.run_light_group_sync("GROUP")
+
+    assert raised.value.phase == "acknowledgement"
+    assert raised.value.response_received is False
+    assert raised.value.onset_seen is False
+    assert captured_old[0].done() and not captured_old[0].cancelled()
+
+
+@pytest.mark.asyncio
+async def test_controller_connection_replacement_cannot_supply_action_edges(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    controller, old_connection = make_controller(frames=[])
+    _fast_lifecycle(monkeypatch)
+    replacement = ScriptedConnection(
+        [make_projection("OFF"), make_projection("OFF"), final_projection("OFF")],
+        action_frames=action_frames("OFF"),
+    )
+    old_future = old_connection.closed
+
+    async def replace_after_dispatch(
+        conn: ScriptedConnection,
+        before: Any,
+        after: Any,
+        _kwargs: dict[str, Any],
+    ) -> dict[str, Any]:
+        before(conn._sequence, asyncio.get_running_loop().time())
+        after(conn._sequence)
+        controller._connection = replacement  # type: ignore[assignment]
+        conn.close_generation()
+        replacement.emit(
+            {
+                "command": "NotifyList",
+                "objectList": [_entry("GROUP", SYNC="ON"), _entry("GROUP", SYNC="OFF")],
+            }
+        )
+        await asyncio.Event().wait()
+        raise AssertionError
+
+    old_connection.scripts[("SetParamList", 1)] = replace_after_dispatch
+
+    with pytest.raises(ICLightGroupError) as raised:
+        await controller.run_light_group_sync("GROUP")
+
+    assert raised.value.phase == "acknowledgement"
+    assert raised.value.onset_seen is False
+    assert controller._connection is replacement
+    assert replacement.observers == []
+    assert old_future.done() and not old_future.cancelled()
+
+
+@pytest.mark.asyncio
+async def test_same_instance_reconnect_wakes_subscription_settle_timer(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    controller, connection = make_controller()
+    monkeypatch.setattr(light_group, "SUBSCRIPTION_SETTLE_SECONDS", 60.0)
+    task = asyncio.create_task(controller.run_light_group_sync("GROUP"))
+    await _eventually(
+        lambda: [call.command for call in connection.calls] == ["GetParamList", "RequestParamList"]
+    )
+    old_future = connection.reconnect_same_instance()
+    connection.emit({"command": "NotifyList", "objectList": [_entry("GROUP", SYNC="ON")]})
+
+    with pytest.raises(ICConnectionError, match="captured connection closed"):
+        await task
+
+    assert old_future.done() and not old_future.cancelled()
+    assert connection.observers == []
+    assert all(call.command != "SetParamList" for call in connection.calls)
+
+
+@pytest.mark.asyncio
+async def test_projected_change_wakes_subscription_settle_timer(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    controller, connection = make_controller()
+    monkeypatch.setattr(light_group, "SUBSCRIPTION_SETTLE_SECONDS", 60.0)
+    task = asyncio.create_task(controller.run_light_group_sync("GROUP"))
+    await _eventually(
+        lambda: [call.command for call in connection.calls] == ["GetParamList", "RequestParamList"]
+    )
+    connection.emit({"command": "NotifyList", "objectList": [_entry("AUX", STATUS="ON")]})
+
+    with pytest.raises(ICError, match="AUX.STATUS") as raised:
+        await task
+
+    assert not isinstance(raised.value, ICLightGroupError)
+    assert connection.observers == []
+    assert all(call.command != "SetParamList" for call in connection.calls)
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize(
+    ("stage", "expected_phase"),
+    [
+        ("first", None),
+        ("subscription", None),
+        ("second", None),
+        ("action", "acknowledgement"),
+        ("final", "final_projection"),
+    ],
+)
+async def test_simultaneous_clean_response_and_close_always_chooses_close(
+    monkeypatch: pytest.MonkeyPatch,
+    stage: str,
+    expected_phase: str | None,
+) -> None:
+    controller, connection = make_controller()
+    _fast_lifecycle(monkeypatch)
+    key = {
+        "first": ("GetParamList", 1),
+        "subscription": ("RequestParamList", 1),
+        "second": ("GetParamList", 2),
+        "action": ("SetParamList", 1),
+        "final": ("GetParamList", 3),
+    }[stage]
+
+    async def close_with_clean_response(
+        conn: ScriptedConnection,
+        before: Any,
+        after: Any,
+        kwargs: dict[str, Any],
+    ) -> dict[str, Any]:
+        if before is not None:
+            before(conn._sequence, asyncio.get_running_loop().time())
+        if after is not None:
+            after(conn._sequence)
+        if stage == "action":
+            for frame in action_frames("OFF"):
+                conn.emit(frame)
+            response = conn.action_response
+        elif stage == "subscription":
+            response = conn._subscription_response(kwargs["objectList"])
+        else:
+            projection = final_projection("OFF") if stage == "final" else make_projection("OFF")
+            response = {
+                "messageID": str(conn._message_id),
+                "response": "200",
+                **projection,
+            }
+        conn.close_generation()
+        return response
+
+    connection.scripts[key] = close_with_clean_response
+
+    if expected_phase is None:
+        with pytest.raises(ICConnectionError, match="captured connection closed"):
+            await controller.run_light_group_sync("GROUP")
+    else:
+        with pytest.raises(ICLightGroupError) as raised:
+            await controller.run_light_group_sync("GROUP")
+        assert raised.value.phase == expected_phase
+        assert isinstance(raised.value.__cause__, ICConnectionError)
+
+    assert connection.closed.done() and not connection.closed.cancelled()
+    assert connection.observers == []
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize(
+    ("edge", "phase"),
+    [("none", "onset"), ("onset", "terminal"), ("terminal", "observation")],
+)
+async def test_disconnect_wakes_onset_terminal_and_observation_waits(
+    monkeypatch: pytest.MonkeyPatch,
+    edge: str,
+    phase: str,
+) -> None:
+    frames: list[dict[str, Any]] = []
+    if edge in {"onset", "terminal"}:
+        frames.append({"command": "NotifyList", "objectList": [_entry("GROUP", SYNC="ON")]})
+    if edge == "terminal":
+        frames.append({"command": "NotifyList", "objectList": [_entry("GROUP", SYNC="OFF")]})
+    controller, connection = make_controller(frames=frames)
+    monkeypatch.setattr(light_group, "SUBSCRIPTION_SETTLE_SECONDS", 0)
+    captured = _capture_tracker(monkeypatch)
+    task = asyncio.create_task(controller.run_light_group_sync("GROUP"))
+    await _eventually(
+        lambda: bool(captured)
+        and captured[0].acknowledged
+        and (edge == "none" or captured[0].onset_seen)
+        and (edge != "terminal" or captured[0].terminal_event.is_set())
+    )
+    old = connection.closed
+    connection.close_generation()
+
+    with pytest.raises(ICLightGroupError) as raised:
+        await task
+
+    assert raised.value.phase == phase
+    assert old.done() and not old.cancelled()
+    assert connection.observers == []
+
+
+@pytest.mark.asyncio
+async def test_disconnect_during_final_read_has_final_projection_phase(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    controller, connection = make_controller()
+    _fast_lifecycle(monkeypatch)
+    final_started = asyncio.Event()
+
+    async def block_final(
+        _conn: ScriptedConnection,
+        before: Any,
+        _after: Any,
+        _kwargs: dict[str, Any],
+    ) -> dict[str, Any]:
+        before(connection._sequence, asyncio.get_running_loop().time())
+        final_started.set()
+        await asyncio.Event().wait()
+        raise AssertionError
+
+    connection.scripts[("GetParamList", 3)] = block_final
+    task = asyncio.create_task(controller.run_light_group_sync("GROUP"))
+    await final_started.wait()
+    old = connection.closed
+    connection.close_generation()
+
+    with pytest.raises(ICLightGroupError) as raised:
+        await task
+
+    assert raised.value.phase == "final_projection"
+    assert raised.value.acknowledged is True
+    assert old.done() and not old.cancelled()
+
+
+@pytest.mark.asyncio
+async def test_close_beats_operation_error_and_tracker_failure_beats_operation_error(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    _fast_lifecycle(monkeypatch)
+    close_controller, close_connection = make_controller()
+
+    async def close_and_raise(
+        conn: ScriptedConnection,
+        _before: Any,
+        _after: Any,
+        _kwargs: dict[str, Any],
+    ) -> dict[str, Any]:
+        conn.close_generation()
+        raise RuntimeError("operation error must lose")
+
+    close_connection.scripts[("RequestParamList", 1)] = close_and_raise
+    with pytest.raises(ICConnectionError, match="captured connection closed"):
+        await close_controller.run_light_group_sync("GROUP")
+
+    failure_controller, failure_connection = make_controller()
+
+    async def fail_and_raise(
+        conn: ScriptedConnection,
+        _before: Any,
+        _after: Any,
+        _kwargs: dict[str, Any],
+    ) -> dict[str, Any]:
+        conn.emit({"command": "NotifyList", "objectList": [_entry("AUX", STATUS="ON")]})
+        raise RuntimeError("operation error must lose")
+
+    failure_connection.scripts[("RequestParamList", 1)] = fail_and_raise
+    with pytest.raises(ICError, match="AUX.STATUS"):
+        await failure_controller.run_light_group_sync("GROUP")
+
+
+@pytest.mark.asyncio
+async def test_cancellation_cleans_children_and_observer_before_lifecycle_exit(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    controller, connection = make_controller(frames=[])
+    _fast_lifecycle(monkeypatch)
+    entered = asyncio.Event()
+    action_cancelled = asyncio.Event()
+
+    async def stalled_action(
+        conn: ScriptedConnection,
+        before: Any,
+        _after: Any,
+        _kwargs: dict[str, Any],
+    ) -> dict[str, Any]:
+        before(conn._sequence, asyncio.get_running_loop().time())
+        entered.set()
+        try:
+            await asyncio.Event().wait()
+        finally:
+            action_cancelled.set()
+
+    connection.scripts[("SetParamList", 1)] = stalled_action
+    original_lifecycle = controller._light_group_mutation_lifecycle
+    exit_snapshots: list[tuple[int, bool, bool, bool, bool]] = []
+
+    @contextlib.asynccontextmanager
+    async def traced_lifecycle() -> Any:
+        async with original_lifecycle() as lease:
+            try:
+                yield lease
+            finally:
+                exit_snapshots.append(
+                    (
+                        len(connection.observers),
+                        action_cancelled.is_set(),
+                        controller._light_group_mutation_pending,
+                        controller._light_group_mutation_lease is lease,
+                        controller._mutation_lock.locked(),
+                    )
+                )
+
+    controller._light_group_mutation_lifecycle = traced_lifecycle  # type: ignore[method-assign]
+    task = asyncio.create_task(controller.run_light_group_sync("GROUP"))
+    await entered.wait()
+    live_close = connection.closed
+    task.cancel()
+
+    with pytest.raises(asyncio.CancelledError):
+        await task
+
+    assert exit_snapshots == [(0, True, True, True, True)]
+    assert connection.remove_count == 1
+    assert controller._light_group_mutation_pending is False
+    assert controller._light_group_mutation_lease is None
+    assert controller._mutation_owner is None
+    assert not controller._mutation_lock.locked()
+    assert not live_close.cancelled()
+
+
+@pytest.mark.asyncio
+async def test_cancellation_before_dispatch_removes_observer_without_a_write(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    controller, connection = make_controller()
+    _fast_lifecycle(monkeypatch)
+    entered = asyncio.Event()
+
+    async def blocked_first_read(
+        _conn: ScriptedConnection,
+        _before: Any,
+        _after: Any,
+        _kwargs: dict[str, Any],
+    ) -> dict[str, Any]:
+        entered.set()
+        await asyncio.Event().wait()
+        raise AssertionError
+
+    connection.scripts[("GetParamList", 1)] = blocked_first_read
+    task = asyncio.create_task(controller.run_light_group_sync("GROUP"))
+    await entered.wait()
+    live_close = connection.closed
+    task.cancel()
+
+    with pytest.raises(asyncio.CancelledError):
+        await task
+
+    assert connection.observers == []
+    assert connection.remove_count == 1
+    assert all(call.command != "SetParamList" for call in connection.calls)
+    assert controller._light_group_mutation_pending is False
+    assert not live_close.cancelled()
+
+
+@pytest.mark.asyncio
+async def test_concurrent_sync_and_writer_fail_busy_while_read_remains_live(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    controller, connection = make_controller(frames=[])
+    _fast_lifecycle(monkeypatch)
+    entered = asyncio.Event()
+
+    async def stalled_action(
+        conn: ScriptedConnection,
+        before: Any,
+        _after: Any,
+        _kwargs: dict[str, Any],
+    ) -> dict[str, Any]:
+        before(conn._sequence, asyncio.get_running_loop().time())
+        entered.set()
+        await asyncio.Event().wait()
+        raise AssertionError
+
+    connection.scripts[("SetParamList", 1)] = stalled_action
+    first = asyncio.create_task(controller.run_light_group_sync("GROUP"))
+    await entered.wait()
+    calls_before = len(connection.calls)
+
+    with pytest.raises(ICError, match="in progress"):
+        await controller.run_light_group_sync("GROUP")
+    with pytest.raises(ICError, match="in progress"):
+        await controller.request_changes("AUX", {"STATUS": "ON"})
+    read_response = await controller.send_cmd("GetFoo")
+
+    assert read_response["response"] == "200"
+    assert len(connection.calls) == calls_before + 1
+    first.cancel()
+    with pytest.raises(asyncio.CancelledError):
+        await first
+    assert controller._light_group_mutation_pending is False

--- a/tests/test_light_group_sync.py
+++ b/tests/test_light_group_sync.py
@@ -2061,10 +2061,12 @@ async def test_disconnect_wakes_onset_terminal_and_observation_waits(
     captured = _capture_tracker(monkeypatch)
     task = asyncio.create_task(controller.run_light_group_sync("GROUP"))
     await _eventually(
-        lambda: bool(captured)
-        and captured[0].acknowledged
-        and (edge == "none" or captured[0].onset_seen)
-        and (edge != "terminal" or captured[0].terminal_event.is_set())
+        lambda: (
+            bool(captured)
+            and captured[0].acknowledged
+            and (edge == "none" or captured[0].onset_seen)
+            and (edge != "terminal" or captured[0].terminal_event.is_set())
+        )
     )
     old = connection.closed
     connection.close_generation()

--- a/tests/test_typing_public_api.py
+++ b/tests/test_typing_public_api.py
@@ -43,11 +43,20 @@ _CONSUMER_SOURCE = textwrap.dedent(
     \"\"\"Downstream-style consumer; must type-check without [abstract] errors.\"\"\"
     from __future__ import annotations
 
-    from pyintellicenter import ICModelController, PoolModel
+    from typing import Any
+
+    from pyintellicenter import ICLightGroupError, ICModelController, PoolModel
 
 
     def make_controller() -> ICModelController:
         return ICModelController("192.168.1.100", PoolModel())
+
+
+    async def run_sync(controller: ICModelController) -> dict[str, Any]:
+        try:
+            return await controller.run_light_group_sync("GROUP")
+        except ICLightGroupError:
+            raise
     """
 )
 


### PR DESCRIPTION
## Summary

- model real circuit/light-group parents as `CIRCUIT` objects and membership rows as `CIRCGRP` objects
- add ordered membership resolution without exposing row objects as controllable circuits
- add a single verified `run_light_group_sync()` action and phase-aware `ICLightGroupError` certainty metadata
- harden notification sequencing, controller mutation ownership, coalescer cleanup, and captured-connection lifecycle checks needed by the action

Related integration work: joyfulhouse/intellicenter#93.

## Supported Color Sync envelope

The writer is deliberately fail-closed and evidence-scoped:

- raw firmware token exactly `1.064`
- one `CIRCUIT/LITSHO` parent with exactly two distinct resolved `CIRCUIT/GLOW` children
- uniform all-off or all-on parent/child prestate
- exact mixed-case one-object `SetParamList` payload containing only `SYNC=ON`
- no retry or recovery write

Broader color-light and version parsing remain read/display helpers only; they do not widen writer eligibility.

## Verified lifecycle

- installs the raw observer before the first wildcard projection and replays a bounded pre-baseline buffer
- validates initialization responses for exact-object subscriptions split at the 50-key ceiling
- requires two exactly equal normalized projections around a one-second subscription settle
- captures the action deadline under the request lock immediately before transport initiation and the causal watermark only after TCP write/WebSocket send completion
- requires a realistic acknowledgement plus strictly post-watermark `SYNC` onset and terminal inside the shared 60-second dispatch deadline
- observes invariants for a separate 60 seconds after terminal, then requires a final wildcard projection on the same captured connection
- monitors all normalized circuit, group-flag, membership-row, and system invariants until observer removal
- blocks later public `SetParamList` mutations immediately during the lifecycle while allowing read-only traffic

Errors expose `phase`, `dispatch_started`, `response_received`, `acknowledged`, and `onset_seen` so callers can distinguish explicit rejection, uncertain dispatch, and incomplete acknowledged/onset outcomes.

## Negative scope

This PR intentionally does **not** add Color Set, Color Swim, member-position writers, generalized firmware support, automatic retry/recovery, or Home Assistant service/version changes.

## Verification

- `uv sync --frozen --extra dev`
- `uv run pytest -q` — 696 passed
- `uv run pytest -q --cov=src/pyintellicenter --cov-report=term-missing` — 696 passed, 89% total coverage
- `uv run ruff check src tests scripts`
- `uv run ruff format --check src tests scripts`
- `uv run mypy src`
- `uv lock --check`
- forbidden-writer and production-caller scope scans

## Adversarial review

- Two internal lifecycle/race reviews found an expired-deadline scheduling race, duplicate cached-system ambiguity, and malformed relevant pre-baseline frames that did not wake the blocked reader. Regression tests and fixes were added; both re-reviews returned GO.
- Cursor `agent` reviewed the complete branch. Its initial concerns about non-target group flags and final all-off behavior conflicted with the captured/frozen contract; its WebSocket test-gap concern was already covered by the real suspended-send transport test plus strict tracker watermark tests. On follow-up it withdrew every finding and returned GO with no blocker/high/medium gap.
- `agy` Opus performed a source-level adversarial audit and validated the WebSocket send-window watermark, subscription normalization, acknowledgement path, writer isolation, and invariant tracking. No blocker/high issue surfaced in its emitted analysis. Its provider quota was reached while formatting the final report, so a clean final-verdict rerun remains pending rather than being represented here as complete.
