### PR TITLE
chore: release 0.1.22

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.1.22] - 2026-07-15
+
 ### Added
 
 - Add dedicated TCP and WebSocket Color Sync for evidence-supported light-group

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "pyintellicenter"
-version = "0.1.21"
+version = "0.1.22"
 description = "Python library for Pentair IntelliCenter pool control systems"
 readme = "README.md"
 license = "MIT"

--- a/src/pyintellicenter/__init__.py
+++ b/src/pyintellicenter/__init__.py
@@ -187,7 +187,7 @@ try:
 except ImportError:
     _DISCOVERY_AVAILABLE = False
 
-__version__ = "0.1.21"
+__version__ = "0.1.22"
 
 __all__ = [
     # Version

--- a/uv.lock
+++ b/uv.lock
@@ -201,7 +201,7 @@ wheels = [
 
 [[package]]
 name = "pyintellicenter"
-version = "0.1.21"
+version = "0.1.22"
 source = { editable = "." }
 dependencies = [
     { name = "orjson" },


### PR DESCRIPTION
## Summary

Release **pyintellicenter 0.1.22** — real circuit/light-group modeling + the evidence-bounded, fail-closed **Color Sync** lifecycle (feature landed in #48), plus a post-review simplification pass.

- Bump `0.1.21` → `0.1.22` in `pyproject.toml`, `__init__.py`, and the `uv.lock` self-reference (drift-guard covers the first two).
- Promote CHANGELOG `[Unreleased]` → `[0.1.22] - 2026-07-15`.

## Feature recap (#48)
- Model `CIRCUIT` light-group parents + `CIRCGRP` membership rows with ordered resolution.
- Single verified `run_light_group_sync()` with phase-aware `ICLightGroupError` certainty metadata.
- Fail-closed writer: exact firmware `1.064`, two distinct `GLOW` children, uniform prestate, watermark-qualified onset/terminal, post-terminal observation, authoritative final read.
- Post-review simplification (`5b23a67`): extract `_is_sentinel`; memoize baseline projection values.

## Test plan
- `ruff` clean · `mypy --strict` clean · **696 tests pass**
- Version drift-guard (`test_version.py`) passes.

After merge: tag `v0.1.22` → triggers the PyPI publish workflow.

🤖 Generated with [Claude Code](https://claude.com/claude-code)